### PR TITLE
Fix prototype blockers and add Railway deployment config

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,8 @@
+node_modules/
+client/node_modules/
+client/build/
+uploads/
+.env
+*.log
+.DS_Store
+.git/

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# Server port (Railway/Render inject this automatically)
+PORT=5000
+
+# Set to "production" when deploying
+NODE_ENV=development
+
+# Comma-separated list of allowed CORS origins (production only).
+# Leave unset when frontend is served from the same origin (recommended).
+# ALLOWED_ORIGINS=https://your-app.up.railway.app

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+uploads/
+.env
+*.log
+.DS_Store
+client/build/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+# Stage 1: Build the React frontend
+FROM node:18-alpine AS frontend-builder
+WORKDIR /app/client
+COPY client/package*.json ./
+RUN npm ci --legacy-peer-deps
+COPY client/ ./
+RUN npm run build
+
+# Stage 2: Production server
+FROM node:18-alpine
+WORKDIR /app
+COPY package.json ./
+# Skip postinstall — frontend already built in stage 1
+RUN npm install --omit=dev --ignore-scripts
+COPY server.js ./
+COPY --from=frontend-builder /app/client/build ./client/build
+ENV NODE_ENV=production
+EXPOSE 8080
+CMD ["node", "server.js"]

--- a/client/package.json
+++ b/client/package.json
@@ -2,6 +2,7 @@
   "name": "client",
   "version": "0.1.0",
   "private": true,
+  "proxy": "http://localhost:5000",
   "dependencies": {
     "@chakra-ui/react": "^3.22.0",
     "@emotion/react": "^11.14.0",
@@ -15,17 +16,10 @@
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "axios": "^1.11.0",
-    "cors": "^2.8.5",
-    "express": "^5.1.0",
     "framer-motion": "^12.23.9",
-    "gravatar": "^1.8.2",
-    "multer": "^2.0.2",
-    "node-fetch": "^3.3.2",
-    "opmlparser": "^0.8.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-scripts": "5.0.1",
-    "sqlite3": "^5.1.7",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"
   },
@@ -52,10 +46,5 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  },
-  "description": "This project was bootstrapped with [Create React App](https://github.com/facebook/create-react-app).",
-  "main": "index.js",
-  "keywords": [],
-  "author": "",
-  "license": "ISC"
+  }
 }

--- a/client/src/App.test.tsx
+++ b/client/src/App.test.tsx
@@ -2,8 +2,8 @@ import React from 'react';
 import { render, screen } from '@testing-library/react';
 import App from './App';
 
-test('renders learn react link', () => {
+test('renders upload heading', () => {
   render(<App />);
-  const linkElement = screen.getByText(/learn react/i);
-  expect(linkElement).toBeInTheDocument();
+  const heading = screen.getByText(/Upload Your Podcast OPML/i);
+  expect(heading).toBeInTheDocument();
 });

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -33,7 +33,7 @@ function App() {
     const formData = new FormData();
     formData.append('opml', file);
     try {
-      const res = await axios.post('http://localhost:5000/api/upload-opml', formData, {
+      const res = await axios.post('/api/upload-opml', formData, {
         headers: { 'Content-Type': 'multipart/form-data' },
       });
       setPodcasts(res.data.podcasts);

--- a/package.json
+++ b/package.json
@@ -12,12 +12,10 @@
     "postinstall": "npm run build"
   },
   "dependencies": {
+    "cors": "^2.8.5",
     "express": "^4.18.2",
     "multer": "^1.4.5-lts.1",
-    "opmlparser": "^2.0.0",
     "node-fetch": "^2.6.7",
-    "sqlite3": "^5.1.6",
-    "cors": "^2.8.5",
-    "gravatar": "^1.8.1"
+    "opmlparser": "^2.0.0"
   }
 }

--- a/railway.toml
+++ b/railway.toml
@@ -1,0 +1,10 @@
+[build]
+builder = "DOCKERFILE"
+dockerfilePath = "Dockerfile"
+
+[deploy]
+startCommand = "node server.js"
+healthcheckPath = "/api/health"
+healthcheckTimeout = 30
+restartPolicyType = "ON_FAILURE"
+restartPolicyMaxRetries = 3

--- a/server.js
+++ b/server.js
@@ -6,35 +6,68 @@ const fs = require('fs');
 const OPMLParser = require('opmlparser');
 
 const app = express();
-const upload = multer({ dest: 'uploads/' });
 
-app.use(cors());
+// CORS: open in development, restricted in production via ALLOWED_ORIGINS env var
+const corsOrigin = process.env.NODE_ENV === 'production'
+  ? (process.env.ALLOWED_ORIGINS ? process.env.ALLOWED_ORIGINS.split(',') : false)
+  : true;
+app.use(cors({ origin: corsOrigin }));
 app.use(express.json());
+
+const upload = multer({
+  dest: 'uploads/',
+  limits: { fileSize: 5 * 1024 * 1024 }, // 5MB max
+  fileFilter: (_req, file, cb) => {
+    if (
+      file.originalname.match(/\.(opml|xml)$/i) ||
+      ['text/xml', 'application/xml', 'text/x-opml'].includes(file.mimetype)
+    ) {
+      cb(null, true);
+    } else {
+      cb(new Error('Only OPML/XML files are allowed'));
+    }
+  }
+});
 
 // Health check
 app.get('/api/health', (req, res) => {
   res.json({ status: 'ok' });
 });
 
-// OPML upload endpoint (to be implemented)
-app.post('/api/upload-opml', upload.single('opml'), (req, res) => {
+// OPML upload endpoint
+app.post('/api/upload-opml', (req, res, next) => {
+  upload.single('opml')(req, res, (err) => {
+    if (err instanceof multer.MulterError && err.code === 'LIMIT_FILE_SIZE') {
+      return res.status(400).json({ error: 'File too large. Maximum size is 5MB.' });
+    }
+    if (err) {
+      return res.status(400).json({ error: err.message });
+    }
+    next();
+  });
+}, (req, res) => {
   if (!req.file) {
     return res.status(400).json({ error: 'No file uploaded' });
   }
 
   const filePath = req.file.path;
   const podcasts = [];
+
+  const cleanup = () => {
+    try { fs.unlinkSync(filePath); } catch (_) {}
+  };
+
   const stream = fs.createReadStream(filePath);
   const opmlparser = new OPMLParser();
 
   stream.pipe(opmlparser)
     .on('error', (err) => {
-      fs.unlinkSync(filePath);
+      cleanup();
       res.status(500).json({ error: 'Failed to parse OPML', details: err.message });
     })
-    .on('readable', function() {
+    .on('readable', function () {
       let outline;
-      while (outline = this.read()) {
+      while ((outline = this.read())) {
         if (outline.xmlurl) {
           podcasts.push({
             title: outline.title || outline.text || '',
@@ -44,7 +77,7 @@ app.post('/api/upload-opml', upload.single('opml'), (req, res) => {
       }
     })
     .on('end', () => {
-      fs.unlinkSync(filePath);
+      cleanup();
       res.json({ podcasts });
     });
 });
@@ -58,7 +91,6 @@ if (process.env.NODE_ENV === 'production') {
   });
 }
 
-// Start server
 const PORT = process.env.PORT || 5000;
 app.listen(PORT, () => {
   console.log(`Server running on port ${PORT}`);


### PR DESCRIPTION
- server.js: add 5MB multer limit, file type validation, production CORS
  restriction via ALLOWED_ORIGINS, and safe file cleanup in all paths
- App.tsx: replace hardcoded localhost:5000 with relative /api path
- App.test.tsx: fix broken CRA boilerplate test to match actual UI
- package.json: remove unused sqlite3 and gravatar dependencies
- client/package.json: remove stray backend deps (express, multer, etc.),
  add CRA proxy to localhost:5000 for local development
- Add .gitignore, .env.example, Dockerfile (multi-stage), .dockerignore,
  and railway.toml for one-click Railway deployment

https://claude.ai/code/session_019dBRz5d85RmqqV8tFkcDmj