### PR TITLE
Add shareable profile URLs with file-based storage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 uploads/
+data/
 .env
 *.log
 .DS_Store

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -23,6 +23,7 @@
         "framer-motion": "^12.23.9",
         "react": "^19.1.0",
         "react-dom": "^19.1.0",
+        "react-router-dom": "^7.14.0",
         "react-scripts": "5.0.1",
         "typescript": "^4.9.5",
         "web-vitals": "^2.1.4"
@@ -15004,6 +15005,57 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/react-router": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.0.tgz",
+      "integrity": "sha512-m/xR9N4LQLmAS0ZhkY2nkPA1N7gQ5TUVa5n8TgANuDTARbn1gt+zLPXEm7W0XDTbrQ2AJSJKhoa6yx1D8BcpxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "cookie": "^1.0.1",
+        "set-cookie-parser": "^2.6.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      },
+      "peerDependenciesMeta": {
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.0.tgz",
+      "integrity": "sha512-2G3ajSVSZMEtmTjIklRWlNvo8wICEpLihfD/0YMDxbWK2UyP5EGfnoIn9AIQGnF3G/FX0MRbHXdFcD+rL1ZreQ==",
+      "license": "MIT",
+      "dependencies": {
+        "react-router": "7.14.0"
+      },
+      "engines": {
+        "node": ">=20.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
+    },
+    "node_modules/react-router/node_modules/cookie": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
     "node_modules/react-scripts": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.1.tgz",
@@ -15846,6 +15898,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/set-cookie-parser": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/set-cookie-parser/-/set-cookie-parser-2.7.2.tgz",
+      "integrity": "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==",
+      "license": "MIT"
     },
     "node_modules/set-function-length": {
       "version": "1.2.2",

--- a/client/package.json
+++ b/client/package.json
@@ -19,6 +19,7 @@
     "framer-motion": "^12.23.9",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-router-dom": "^7.14.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.9.5",
     "web-vitals": "^2.1.4"

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,62 +1,19 @@
-import React, { useState } from 'react';
+import React from 'react';
 import {
   ChakraProvider,
   defaultSystem,
-  Box,
-  Heading,
-  VStack,
-  Input,
-  Button,
-  Text,
-  ListRoot,
-  ListItem,
-  Spinner,
-  createToaster,
   Toaster,
   ToastRoot,
   ToastTitle,
   ToastDescription,
   ToastCloseTrigger,
 } from '@chakra-ui/react';
-import axios from 'axios';
-
-const toaster = createToaster({ placement: 'top-end' });
+import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { toaster } from './toaster';
+import UploadPage from './UploadPage';
+import ProfilePage from './ProfilePage';
 
 function App() {
-  const [file, setFile] = useState<File | null>(null);
-  const [loading, setLoading] = useState(false);
-  const [podcasts, setPodcasts] = useState<Array<{ title: string; xmlurl: string }>>([]);
-
-  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    if (e.target.files && e.target.files[0]) {
-      setFile(e.target.files[0]);
-    }
-  };
-
-  const handleUpload = async () => {
-    if (!file) return;
-    setLoading(true);
-    setPodcasts([]);
-    const formData = new FormData();
-    formData.append('opml', file);
-    try {
-      const res = await axios.post('/api/upload-opml', formData, {
-        headers: { 'Content-Type': 'multipart/form-data' },
-      });
-      setPodcasts(res.data.podcasts);
-      toaster.create({ title: 'OPML parsed!', type: 'success', duration: 2000 });
-    } catch (err: any) {
-      toaster.create({
-        title: 'Failed to parse OPML',
-        description: err?.response?.data?.error || err.message,
-        type: 'error',
-        duration: 3000,
-      });
-    } finally {
-      setLoading(false);
-    }
-  };
-
   return (
     <ChakraProvider value={defaultSystem}>
       <Toaster toaster={toaster}>
@@ -68,29 +25,12 @@ function App() {
           </ToastRoot>
         )}
       </Toaster>
-      <Box minH="100vh" bg="gray.50" py={10} px={4}>
-        <VStack gap={8} maxW="lg" mx="auto" bg="white" p={8} borderRadius="lg" boxShadow="md">
-          <Heading as="h1" size="lg">Upload Your Podcast OPML</Heading>
-          <Input type="file" accept=".opml,.xml" onChange={handleFileChange} disabled={loading} />
-          <Button colorPalette="blue" onClick={handleUpload} loading={loading} disabled={!file || loading}>
-            Upload & Parse
-          </Button>
-          {loading && <Spinner />}
-          {podcasts.length > 0 && (
-            <Box w="100%">
-              <Heading as="h2" size="md" mb={2}>Podcasts Found</Heading>
-              <ListRoot gap={2}>
-                {podcasts.map((p, i) => (
-                  <ListItem key={i}>
-                    <Text fontWeight="bold">{p.title || p.xmlurl}</Text>
-                    <Text fontSize="sm" color="gray.500">{p.xmlurl}</Text>
-                  </ListItem>
-                ))}
-              </ListRoot>
-            </Box>
-          )}
-        </VStack>
-      </Box>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/" element={<UploadPage />} />
+          <Route path="/p/:hash" element={<ProfilePage />} />
+        </Routes>
+      </BrowserRouter>
     </ChakraProvider>
   );
 }

--- a/client/src/ProfilePage.tsx
+++ b/client/src/ProfilePage.tsx
@@ -1,0 +1,101 @@
+import React, { useEffect, useState } from 'react';
+import { useParams, useNavigate } from 'react-router-dom';
+import {
+  Box,
+  Heading,
+  VStack,
+  Text,
+  ListRoot,
+  ListItem,
+  Spinner,
+  Button,
+} from '@chakra-ui/react';
+import axios from 'axios';
+import { toaster } from './toaster';
+
+interface Podcast {
+  title: string;
+  xmlurl: string;
+}
+
+interface Profile {
+  hash: string;
+  podcasts: Podcast[];
+  created_at: string;
+}
+
+function ProfilePage() {
+  const { hash } = useParams<{ hash: string }>();
+  const navigate = useNavigate();
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [notFound, setNotFound] = useState(false);
+
+  useEffect(() => {
+    axios.get(`/api/profiles/${hash}`)
+      .then(res => setProfile(res.data))
+      .catch(err => {
+        if (err.response?.status === 404) {
+          setNotFound(true);
+        } else {
+          toaster.create({ title: 'Failed to load profile', type: 'error', duration: 3000 });
+          setNotFound(true);
+        }
+      })
+      .finally(() => setLoading(false));
+  }, [hash]);
+
+  const handleShare = async () => {
+    const url = window.location.href;
+    if (typeof navigator.share !== 'undefined') {
+      try {
+        await navigator.share({ title: 'Podcast Profile', url });
+      } catch (err: any) {
+        if (err.name !== 'AbortError') {
+          await navigator.clipboard.writeText(url);
+          toaster.create({ title: 'Link copied!', type: 'success', duration: 1500 });
+        }
+      }
+    } else {
+      await navigator.clipboard.writeText(url);
+      toaster.create({ title: 'Link copied!', type: 'success', duration: 1500 });
+    }
+  };
+
+  return (
+    <Box minH="100vh" bg="gray.50" py={10} px={4}>
+      <VStack gap={8} maxW="lg" mx="auto" bg="white" p={8} borderRadius="lg" boxShadow="md">
+        {loading && <Spinner size="xl" />}
+
+        {notFound && (
+          <>
+            <Heading as="h1" size="lg">Profile Not Found</Heading>
+            <Text color="gray.500">This profile doesn't exist or has been removed.</Text>
+            <Button colorPalette="blue" onClick={() => navigate('/')}>Create Your Own Profile</Button>
+          </>
+        )}
+
+        {profile && (
+          <>
+            <Heading as="h1" size="lg">Podcast Profile</Heading>
+            <Text color="gray.500">{profile.podcasts.length} podcasts</Text>
+            <Button colorPalette="blue" onClick={handleShare} w="100%">Share This Profile</Button>
+            <Box w="100%">
+              <ListRoot gap={2}>
+                {profile.podcasts.map((p, i) => (
+                  <ListItem key={i}>
+                    <Text fontWeight="bold">{p.title || p.xmlurl}</Text>
+                    <Text fontSize="sm" color="gray.500">{p.xmlurl}</Text>
+                  </ListItem>
+                ))}
+              </ListRoot>
+            </Box>
+            <Button variant="ghost" onClick={() => navigate('/')}>Create Your Own Profile</Button>
+          </>
+        )}
+      </VStack>
+    </Box>
+  );
+}
+
+export default ProfilePage;

--- a/client/src/UploadPage.tsx
+++ b/client/src/UploadPage.tsx
@@ -1,0 +1,146 @@
+import React, { useState } from 'react';
+import {
+  Box,
+  Heading,
+  VStack,
+  Input,
+  Button,
+  Text,
+  ListRoot,
+  ListItem,
+  Spinner,
+} from '@chakra-ui/react';
+import { useNavigate } from 'react-router-dom';
+import axios from 'axios';
+import { toaster } from './toaster';
+
+interface Podcast {
+  title: string;
+  xmlurl: string;
+}
+
+function UploadPage() {
+  const navigate = useNavigate();
+  const [file, setFile] = useState<File | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [podcasts, setPodcasts] = useState<Podcast[]>([]);
+  const [shareUrl, setShareUrl] = useState<string | null>(null);
+
+  const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    if (e.target.files && e.target.files[0]) {
+      setFile(e.target.files[0]);
+      setPodcasts([]);
+      setShareUrl(null);
+    }
+  };
+
+  const handleUpload = async () => {
+    if (!file) return;
+    setLoading(true);
+    setPodcasts([]);
+    setShareUrl(null);
+    const formData = new FormData();
+    formData.append('opml', file);
+    try {
+      const res = await axios.post('/api/upload-opml', formData, {
+        headers: { 'Content-Type': 'multipart/form-data' },
+      });
+      setPodcasts(res.data.podcasts);
+      toaster.create({ title: 'OPML parsed!', type: 'success', duration: 2000 });
+    } catch (err: any) {
+      toaster.create({
+        title: 'Failed to parse OPML',
+        description: err?.response?.data?.error || err.message,
+        type: 'error',
+        duration: 3000,
+      });
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  const handleSaveProfile = async () => {
+    setSaving(true);
+    try {
+      const res = await axios.post('/api/profiles', { podcasts });
+      const url = `${window.location.origin}/p/${res.data.hash}`;
+      setShareUrl(url);
+
+      if (typeof navigator.share !== 'undefined') {
+        try {
+          await navigator.share({ title: 'My Podcast Profile', url });
+        } catch (err: any) {
+          if (err.name !== 'AbortError') {
+            await navigator.clipboard.writeText(url);
+            toaster.create({ title: 'Link copied to clipboard!', type: 'success', duration: 2000 });
+          }
+        }
+      } else {
+        await navigator.clipboard.writeText(url);
+        toaster.create({ title: 'Link copied to clipboard!', type: 'success', duration: 2000 });
+      }
+    } catch (err: any) {
+      toaster.create({
+        title: 'Failed to save profile',
+        description: err?.response?.data?.error || err.message,
+        type: 'error',
+        duration: 3000,
+      });
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleCopyUrl = async () => {
+    if (!shareUrl) return;
+    await navigator.clipboard.writeText(shareUrl);
+    toaster.create({ title: 'Link copied!', type: 'success', duration: 1500 });
+  };
+
+  return (
+    <Box minH="100vh" bg="gray.50" py={10} px={4}>
+      <VStack gap={8} maxW="lg" mx="auto" bg="white" p={8} borderRadius="lg" boxShadow="md">
+        <Heading as="h1" size="lg">Upload Your Podcast OPML</Heading>
+        <Input type="file" accept=".opml,.xml" onChange={handleFileChange} disabled={loading} />
+        <Button colorPalette="blue" onClick={handleUpload} loading={loading} disabled={!file || loading}>
+          Upload & Parse
+        </Button>
+        {loading && <Spinner />}
+        {podcasts.length > 0 && (
+          <Box w="100%">
+            <Heading as="h2" size="md" mb={4}>{podcasts.length} Podcasts Found</Heading>
+
+            {shareUrl ? (
+              <Box p={4} bg="green.50" borderRadius="md" border="1px solid" borderColor="green.200" mb={4}>
+                <Text fontWeight="bold" mb={2}>Your profile is ready to share:</Text>
+                <Text fontSize="sm" color="gray.600" wordBreak="break-all" mb={3}>{shareUrl}</Text>
+                <VStack gap={2} align="stretch">
+                  <Button size="sm" colorPalette="green" onClick={handleCopyUrl}>Copy Link</Button>
+                  <Button size="sm" variant="ghost" onClick={() => navigate(`/p/${shareUrl.split('/p/')[1]}`)}>
+                    View Profile
+                  </Button>
+                </VStack>
+              </Box>
+            ) : (
+              <Button colorPalette="green" onClick={handleSaveProfile} loading={saving} mb={4} w="100%">
+                Create Shareable Profile
+              </Button>
+            )}
+
+            <ListRoot gap={2}>
+              {podcasts.map((p, i) => (
+                <ListItem key={i}>
+                  <Text fontWeight="bold">{p.title || p.xmlurl}</Text>
+                  <Text fontSize="sm" color="gray.500">{p.xmlurl}</Text>
+                </ListItem>
+              ))}
+            </ListRoot>
+          </Box>
+        )}
+      </VStack>
+    </Box>
+  );
+}
+
+export default UploadPage;

--- a/client/src/toaster.ts
+++ b/client/src/toaster.ts
@@ -1,0 +1,3 @@
+import { createToaster } from '@chakra-ui/react';
+
+export const toaster = createToaster({ placement: 'top-end' });

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const multer = require('multer');
 const cors = require('cors');
 const path = require('path');
 const fs = require('fs');
+const crypto = require('crypto');
 const OPMLParser = require('opmlparser');
 
 const app = express();
@@ -28,6 +29,42 @@ const upload = multer({
     }
   }
 });
+
+// File-based profile storage
+// Set DATA_DIR env var to a persistent volume path on Railway
+const DATA_DIR = process.env.DATA_DIR || path.join(__dirname, 'data');
+
+function ensureDataDir() {
+  if (!fs.existsSync(DATA_DIR)) {
+    fs.mkdirSync(DATA_DIR, { recursive: true });
+  }
+}
+
+// Validate hash to prevent path traversal
+function isValidHash(hash) {
+  return typeof hash === 'string' && /^[A-Za-z0-9_-]{8}$/.test(hash);
+}
+
+function generateHash() {
+  return crypto.randomBytes(6).toString('base64url');
+}
+
+function saveProfile(hash, podcasts) {
+  ensureDataDir();
+  const filePath = path.join(DATA_DIR, `${hash}.json`);
+  fs.writeFileSync(filePath, JSON.stringify({
+    hash,
+    podcasts,
+    created_at: new Date().toISOString()
+  }));
+}
+
+function loadProfile(hash) {
+  if (!isValidHash(hash)) return null;
+  const filePath = path.join(DATA_DIR, `${hash}.json`);
+  if (!fs.existsSync(filePath)) return null;
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
 
 // Health check
 app.get('/api/health', (req, res) => {
@@ -80,6 +117,40 @@ app.post('/api/upload-opml', (req, res, next) => {
       cleanup();
       res.json({ podcasts });
     });
+});
+
+// Save a podcast profile and return a shareable hash
+app.post('/api/profiles', (req, res) => {
+  const { podcasts } = req.body;
+  if (!Array.isArray(podcasts) || podcasts.length === 0) {
+    return res.status(400).json({ error: 'podcasts must be a non-empty array' });
+  }
+
+  // Generate a unique hash (retry on collision)
+  let hash;
+  let attempts = 0;
+  do {
+    hash = generateHash();
+    attempts++;
+  } while (fs.existsSync(path.join(DATA_DIR, `${hash}.json`)) && attempts < 5);
+
+  try {
+    saveProfile(hash, podcasts);
+    res.json({ hash });
+  } catch (err) {
+    console.error('Failed to save profile:', err);
+    res.status(500).json({ error: 'Failed to save profile' });
+  }
+});
+
+// Retrieve a profile by hash
+app.get('/api/profiles/:hash', (req, res) => {
+  const { hash } = req.params;
+  const profile = loadProfile(hash);
+  if (!profile) {
+    return res.status(404).json({ error: 'Profile not found' });
+  }
+  res.json(profile);
 });
 
 // Serve React build in production


### PR DESCRIPTION
- POST /api/profiles saves a podcast list as a JSON file under data/
  and returns an 8-char base64url hash
- GET /api/profiles/:hash retrieves a saved profile
- React Router routes: / (upload) and /p/:hash (profile view)
- UploadPage: "Create Shareable Profile" button after OPML parse, shows
  share URL and triggers native Web Share API with clipboard fallback
- ProfilePage: displays any shared profile with a share button
- Shared toaster.ts so both pages use the same toast instance
- DATA_DIR env var lets Railway users point to a persistent volume

https://claude.ai/code/session_01Vr9MMJjanS6fcJGM8vPEXr