### PR TITLE
Add SQLite persistence and per-profile name setting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,12 @@ RUN npm run build
 
 # Stage 2: Production server
 FROM node:18-alpine
+# Build tools required for native modules (better-sqlite3)
+RUN apk add --no-cache python3 make g++
 WORKDIR /app
 COPY package.json ./
-# Skip postinstall — frontend already built in stage 1
-RUN npm install --omit=dev --ignore-scripts
+# Skip postinstall (frontend already built in stage 1), then rebuild native modules
+RUN npm install --omit=dev --ignore-scripts && npm rebuild better-sqlite3
 COPY server.js ./
 COPY --from=frontend-builder /app/client/build ./client/build
 ENV NODE_ENV=production

--- a/client/src/ProfilePage.tsx
+++ b/client/src/ProfilePage.tsx
@@ -4,11 +4,13 @@ import {
   Box,
   Heading,
   VStack,
+  HStack,
   Text,
   ListRoot,
   ListItem,
   Spinner,
   Button,
+  Input,
 } from '@chakra-ui/react';
 import axios from 'axios';
 import { toaster } from './toaster';
@@ -20,6 +22,7 @@ interface Podcast {
 
 interface Profile {
   hash: string;
+  name: string | null;
   podcasts: Podcast[];
   created_at: string;
 }
@@ -31,9 +34,15 @@ function ProfilePage() {
   const [loading, setLoading] = useState(true);
   const [notFound, setNotFound] = useState(false);
 
+  const [nameInput, setNameInput] = useState('');
+  const [savingName, setSavingName] = useState(false);
+
   useEffect(() => {
     axios.get(`/api/profiles/${hash}`)
-      .then(res => setProfile(res.data))
+      .then(res => {
+        setProfile(res.data);
+        setNameInput(res.data.name || '');
+      })
       .catch(err => {
         if (err.response?.status === 404) {
           setNotFound(true);
@@ -44,6 +53,20 @@ function ProfilePage() {
       })
       .finally(() => setLoading(false));
   }, [hash]);
+
+  const handleSaveName = async () => {
+    if (!nameInput.trim()) return;
+    setSavingName(true);
+    try {
+      const res = await axios.patch(`/api/profiles/${hash}`, { name: nameInput.trim() });
+      setProfile(prev => prev ? { ...prev, name: res.data.name } : prev);
+      toaster.create({ title: 'Name saved!', type: 'success', duration: 1500 });
+    } catch {
+      toaster.create({ title: 'Failed to save name', type: 'error', duration: 3000 });
+    } finally {
+      setSavingName(false);
+    }
+  };
 
   const handleShare = async () => {
     const url = window.location.href;
@@ -77,7 +100,35 @@ function ProfilePage() {
 
         {profile && (
           <>
-            <Heading as="h1" size="lg">Podcast Profile</Heading>
+            <Heading as="h1" size="lg">
+              {profile.name ? `${profile.name}'s Profile` : 'Podcast Profile'}
+            </Heading>
+
+            {/* Name form */}
+            <Box w="100%" p={4} bg="gray.50" borderRadius="md">
+              <Text fontSize="sm" fontWeight="semibold" mb={2} color="gray.600">
+                {profile.name ? 'Your name' : 'Set your name'}
+              </Text>
+              <HStack>
+                <Input
+                  value={nameInput}
+                  onChange={e => setNameInput(e.target.value)}
+                  placeholder="Enter your name"
+                  size="sm"
+                  onKeyDown={e => e.key === 'Enter' && handleSaveName()}
+                />
+                <Button
+                  size="sm"
+                  colorPalette="blue"
+                  onClick={handleSaveName}
+                  loading={savingName}
+                  disabled={!nameInput.trim() || savingName}
+                >
+                  Save
+                </Button>
+              </HStack>
+            </Box>
+
             <Text color="gray.500">{profile.podcasts.length} podcasts</Text>
             <Button colorPalette="blue" onClick={handleShare} w="100%">Share This Profile</Button>
             <Box w="100%">

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "postinstall": "npm run build"
   },
   "dependencies": {
+    "better-sqlite3": "^9.4.3",
     "cors": "^2.8.5",
     "express": "^4.18.2",
     "multer": "^1.4.5-lts.1",

--- a/server.js
+++ b/server.js
@@ -5,6 +5,7 @@ const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
 const OPMLParser = require('opmlparser');
+const Database = require('better-sqlite3');
 
 const app = express();
 
@@ -30,8 +31,8 @@ const upload = multer({
   }
 });
 
-// File-based profile storage
-// Set DATA_DIR env var to a persistent volume path on Railway
+// SQLite-backed profile storage.
+// Set DATA_DIR env var to a persistent volume path on Railway so the DB survives redeploys.
 const DATA_DIR = process.env.DATA_DIR || path.join(__dirname, 'data');
 
 function ensureDataDir() {
@@ -40,7 +41,24 @@ function ensureDataDir() {
   }
 }
 
-// Validate hash to prevent path traversal
+let _db;
+function getDb() {
+  if (!_db) {
+    ensureDataDir();
+    _db = new Database(path.join(DATA_DIR, 'profiles.db'));
+    _db.exec(`
+      CREATE TABLE IF NOT EXISTS profiles (
+        hash       TEXT PRIMARY KEY,
+        name       TEXT,
+        podcasts   TEXT NOT NULL,
+        created_at TEXT NOT NULL
+      )
+    `);
+  }
+  return _db;
+}
+
+// Validate hash to prevent path traversal / SQL injection via param
 function isValidHash(hash) {
   return typeof hash === 'string' && /^[A-Za-z0-9_-]{8}$/.test(hash);
 }
@@ -49,21 +67,33 @@ function generateHash() {
   return crypto.randomBytes(6).toString('base64url');
 }
 
+function hashExists(hash) {
+  return !!getDb().prepare('SELECT 1 FROM profiles WHERE hash = ?').get(hash);
+}
+
 function saveProfile(hash, podcasts) {
-  ensureDataDir();
-  const filePath = path.join(DATA_DIR, `${hash}.json`);
-  fs.writeFileSync(filePath, JSON.stringify({
-    hash,
-    podcasts,
-    created_at: new Date().toISOString()
-  }));
+  getDb()
+    .prepare('INSERT INTO profiles (hash, podcasts, created_at) VALUES (?, ?, ?)')
+    .run(hash, JSON.stringify(podcasts), new Date().toISOString());
 }
 
 function loadProfile(hash) {
   if (!isValidHash(hash)) return null;
-  const filePath = path.join(DATA_DIR, `${hash}.json`);
-  if (!fs.existsSync(filePath)) return null;
-  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  const row = getDb().prepare('SELECT * FROM profiles WHERE hash = ?').get(hash);
+  if (!row) return null;
+  return {
+    hash: row.hash,
+    name: row.name || null,
+    podcasts: JSON.parse(row.podcasts),
+    created_at: row.created_at,
+  };
+}
+
+function updateProfileName(hash, name) {
+  const result = getDb()
+    .prepare('UPDATE profiles SET name = ? WHERE hash = ?')
+    .run(name, hash);
+  return result.changes > 0;
 }
 
 // Health check
@@ -132,7 +162,7 @@ app.post('/api/profiles', (req, res) => {
   do {
     hash = generateHash();
     attempts++;
-  } while (fs.existsSync(path.join(DATA_DIR, `${hash}.json`)) && attempts < 5);
+  } while (hashExists(hash) && attempts < 5);
 
   try {
     saveProfile(hash, podcasts);
@@ -151,6 +181,27 @@ app.get('/api/profiles/:hash', (req, res) => {
     return res.status(404).json({ error: 'Profile not found' });
   }
   res.json(profile);
+});
+
+// Update a profile's name
+app.patch('/api/profiles/:hash', (req, res) => {
+  const { hash } = req.params;
+  if (!isValidHash(hash)) {
+    return res.status(400).json({ error: 'Invalid profile id' });
+  }
+
+  const { name } = req.body;
+  if (typeof name !== 'string' || name.trim().length === 0) {
+    return res.status(400).json({ error: 'name must be a non-empty string' });
+  }
+
+  const trimmed = name.trim().slice(0, 100);
+  const updated = updateProfileName(hash, trimmed);
+  if (!updated) {
+    return res.status(404).json({ error: 'Profile not found' });
+  }
+
+  res.json({ name: trimmed });
 });
 
 // Serve React build in production


### PR DESCRIPTION
- Replace per-file JSON storage with a single SQLite database (better-sqlite3)
  so profiles survive container redeploys when DATA_DIR is a persistent volume
- Add `name` column to profiles table
- Add PATCH /api/profiles/:hash endpoint to save a display name (max 100 chars)
- ProfilePage: inline name form lets users personalise their profile after creation;
  heading updates to "<Name>'s Profile" once a name is saved
- Dockerfile: add python3/make/g++ build tools so better-sqlite3 native addon compiles

https://claude.ai/code/session_01RfjgovtHoeRc6qWadoEy66