### PR TITLE
Enrich podcast metadata from feeds with 24-hour cache

### DIFF
--- a/client/src/ProfilePage.tsx
+++ b/client/src/ProfilePage.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
   Box,
+  Badge,
   Heading,
   VStack,
   HStack,
@@ -27,6 +28,46 @@ interface Profile {
   created_at: string;
 }
 
+interface PodcastMetadata {
+  description: string | null;
+  artwork: string | null;
+  categories: string[];
+  latestEpisode: {
+    title: string | null;
+    date: string | null;
+  };
+  frequency: string | null;
+}
+
+function formatRelativeDate(isoDate: string): string {
+  const date = new Date(isoDate);
+  const days = Math.floor((Date.now() - date.getTime()) / (1000 * 60 * 60 * 24));
+  if (days === 0) return 'today';
+  if (days === 1) return 'yesterday';
+  if (days < 7) return `${days}d ago`;
+  if (days < 30) return `${Math.floor(days / 7)}w ago`;
+  if (days < 365) return `${Math.floor(days / 30)}mo ago`;
+  return `${Math.floor(days / 365)}y ago`;
+}
+
+const FREQUENCY_PALETTE: Record<string, string> = {
+  daily: 'green',
+  weekly: 'green',
+  biweekly: 'teal',
+  monthly: 'yellow',
+  occasional: 'orange',
+  dormant: 'red',
+};
+
+const FREQUENCY_LABEL: Record<string, string> = {
+  daily: 'Daily',
+  weekly: 'Weekly',
+  biweekly: 'Bi-weekly',
+  monthly: 'Monthly',
+  occasional: 'Occasional',
+  dormant: 'Dormant',
+};
+
 function ProfilePage() {
   const { hash } = useParams<{ hash: string }>();
   const navigate = useNavigate();
@@ -37,11 +78,15 @@ function ProfilePage() {
   const [nameInput, setNameInput] = useState('');
   const [savingName, setSavingName] = useState(false);
 
+  const [enriched, setEnriched] = useState<Record<string, PodcastMetadata | null>>({});
+  const [enriching, setEnriching] = useState(false);
+
   useEffect(() => {
     axios.get(`/api/profiles/${hash}`)
       .then(res => {
         setProfile(res.data);
         setNameInput(res.data.name || '');
+        enrichPodcasts(res.data.podcasts);
       })
       .catch(err => {
         if (err.response?.status === 404) {
@@ -52,7 +97,22 @@ function ProfilePage() {
         }
       })
       .finally(() => setLoading(false));
-  }, [hash]);
+  }, [hash]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const enrichPodcasts = async (podcasts: Podcast[]) => {
+    if (podcasts.length === 0) return;
+    setEnriching(true);
+    try {
+      const res = await axios.post('/api/podcasts/enrich', {
+        xmlurls: podcasts.map(p => p.xmlurl),
+      });
+      setEnriched(res.data);
+    } catch (err) {
+      console.error('Failed to enrich podcasts', err);
+    } finally {
+      setEnriching(false);
+    }
+  };
 
   const handleSaveName = async () => {
     if (!nameInput.trim()) return;
@@ -87,7 +147,7 @@ function ProfilePage() {
 
   return (
     <Box minH="100vh" bg="gray.50" py={10} px={4}>
-      <VStack gap={8} maxW="lg" mx="auto" bg="white" p={8} borderRadius="lg" boxShadow="md">
+      <VStack gap={8} maxW="2xl" mx="auto" bg="white" p={8} borderRadius="lg" boxShadow="md">
         {loading && <Spinner size="xl" />}
 
         {notFound && (
@@ -129,18 +189,109 @@ function ProfilePage() {
               </HStack>
             </Box>
 
-            <Text color="gray.500">{profile.podcasts.length} podcasts</Text>
+            <HStack w="100%" justify="space-between" align="center">
+              <Text color="gray.500">{profile.podcasts.length} podcasts</Text>
+              {enriching && (
+                <HStack gap={2}>
+                  <Spinner size="sm" />
+                  <Text fontSize="sm" color="gray.400">Loading details…</Text>
+                </HStack>
+              )}
+            </HStack>
+
             <Button colorPalette="blue" onClick={handleShare} w="100%">Share This Profile</Button>
+
             <Box w="100%">
-              <ListRoot gap={2}>
-                {profile.podcasts.map((p, i) => (
-                  <ListItem key={i}>
-                    <Text fontWeight="bold">{p.title || p.xmlurl}</Text>
-                    <Text fontSize="sm" color="gray.500">{p.xmlurl}</Text>
-                  </ListItem>
-                ))}
+              <ListRoot gap={4}>
+                {profile.podcasts.map((p, i) => {
+                  const meta = enriched[p.xmlurl];
+                  return (
+                    <ListItem key={i} listStyle="none">
+                      <HStack gap={3} align="start">
+                        {/* Artwork */}
+                        {meta?.artwork && (
+                          <Box flexShrink={0}>
+                            <img
+                              src={meta.artwork}
+                              alt=""
+                              width={64}
+                              height={64}
+                              style={{ borderRadius: 8, objectFit: 'cover', display: 'block' }}
+                              onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                            />
+                          </Box>
+                        )}
+
+                        <Box flex={1} minW={0}>
+                          {/* Title + frequency badge */}
+                          <HStack justify="space-between" align="start" gap={2}>
+                            <Text fontWeight="bold" style={{ overflowWrap: 'anywhere' }}>
+                              {p.title || p.xmlurl}
+                            </Text>
+                            {meta?.frequency && meta.frequency !== 'unknown' && (
+                              <Badge
+                                colorPalette={FREQUENCY_PALETTE[meta.frequency] ?? 'gray'}
+                                variant="subtle"
+                                flexShrink={0}
+                                size="sm"
+                              >
+                                {FREQUENCY_LABEL[meta.frequency] ?? meta.frequency}
+                              </Badge>
+                            )}
+                          </HStack>
+
+                          {/* Description */}
+                          {meta?.description && (
+                            <Text
+                              fontSize="sm"
+                              color="gray.600"
+                              mt={1}
+                              style={{
+                                display: '-webkit-box',
+                                WebkitLineClamp: 2,
+                                WebkitBoxOrient: 'vertical',
+                                overflow: 'hidden',
+                              } as React.CSSProperties}
+                            >
+                              {meta.description}
+                            </Text>
+                          )}
+
+                          {/* Categories */}
+                          {meta?.categories && meta.categories.length > 0 && (
+                            <HStack gap={1} mt={1} flexWrap="wrap">
+                              {meta.categories.slice(0, 3).map((cat, ci) => (
+                                <Badge key={ci} colorPalette="blue" variant="outline" size="sm">
+                                  {cat}
+                                </Badge>
+                              ))}
+                            </HStack>
+                          )}
+
+                          {/* Latest episode */}
+                          {meta?.latestEpisode?.title && (
+                            <Text fontSize="xs" color="gray.400" mt={1} noOfLines={1}>
+                              Latest: {meta.latestEpisode.title}
+                              {meta.latestEpisode.date && (
+                                <> · {formatRelativeDate(meta.latestEpisode.date)}</>
+                              )}
+                            </Text>
+                          )}
+
+                          {/* Feed URL (shown when no description loaded yet) */}
+                          {!meta?.description && (
+                            <Text fontSize="xs" color="gray.400" mt={1} style={{ overflowWrap: 'anywhere' }}>
+                              {p.xmlurl}
+                            </Text>
+                          )}
+                        </Box>
+                      </HStack>
+                    </ListItem>
+                  );
+                })}
               </ListRoot>
             </Box>
+
             <Button variant="ghost" onClick={() => navigate('/')}>Create Your Own Profile</Button>
           </>
         )}

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,8 +9,10 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "better-sqlite3": "^9.4.3",
         "cors": "^2.8.5",
         "express": "^4.18.2",
+        "fast-xml-parser": "^4.5.6",
         "multer": "^1.4.5-lts.1",
         "node-fetch": "^2.6.7",
         "opmlparser": "^0.8.0"
@@ -44,6 +46,71 @@
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
     },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/better-sqlite3": {
+      "version": "9.6.0",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-9.6.0.tgz",
+      "integrity": "sha512-yR5HATnqeYNVnkaUTf4bOP2dJSnyhP4puJN/QPRyx4YkBEEUxib422n2XzPqDEHjQQqazoYoADdAm5vE15+dAQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "prebuild-install": "^7.1.1"
+      }
+    },
+    "node_modules/bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "license": "MIT",
+      "dependencies": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "node_modules/bl": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+      "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer": "^5.5.0",
+        "inherits": "^2.0.4",
+        "readable-stream": "^3.4.0"
+      }
+    },
+    "node_modules/bl/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/body-parser": {
       "version": "1.20.4",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.4.tgz",
@@ -66,6 +133,30 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "node_modules/buffer-from": {
@@ -122,6 +213,12 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "license": "ISC"
     },
     "node_modules/concat-stream": {
       "version": "1.6.2",
@@ -206,6 +303,30 @@
         "ms": "2.0.0"
       }
     },
+    "node_modules/decompress-response": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+      "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mimic-response": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -223,6 +344,15 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/dunder-proto": {
@@ -252,6 +382,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.5",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
+      "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -297,6 +436,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "license": "(MIT OR WTFPL)",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/express": {
@@ -345,6 +493,30 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-xml-parser": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.6.tgz",
+      "integrity": "sha512-Yd4vkROfJf8AuJrDIVMVmYfULKmIJszVsMv7Vo71aocsKgFxpdlpSHXSaInvyYfgw2PRuObQSW2GFpVMUjxu9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
+      }
+    },
+    "node_modules/file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "license": "MIT"
+    },
     "node_modules/finalhandler": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.2.tgz",
@@ -380,6 +552,12 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "license": "MIT"
     },
     "node_modules/function-bind": {
       "version": "1.1.2",
@@ -426,6 +604,12 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
+      "license": "MIT"
     },
     "node_modules/gopd": {
       "version": "1.2.0",
@@ -495,10 +679,36 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "license": "ISC"
+    },
+    "node_modules/ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
       "license": "ISC"
     },
     "node_modules/ipaddr.js": {
@@ -585,6 +795,18 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/mimic-response": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+      "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -605,6 +827,12 @@
       "bin": {
         "mkdirp": "bin/cmd.js"
       }
+    },
+    "node_modules/mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.0.0",
@@ -631,6 +859,12 @@
         "node": ">= 6.0.0"
       }
     },
+    "node_modules/napi-build-utils": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-2.0.0.tgz",
+      "integrity": "sha512-GEbrYkbfF7MoNaoh2iGG84Mnf/WZfB0GdGEsM8wz7Expx/LlWf5U8t9nvJKXSp3qr5IsEbK04cBGhol/KwOsWA==",
+      "license": "MIT"
+    },
     "node_modules/negotiator": {
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
@@ -638,6 +872,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-abi": {
+      "version": "3.89.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.89.0.tgz",
+      "integrity": "sha512-6u9UwL0HlAl21+agMN3YAMXcKByMqwGx+pq+P76vii5f7hTPtKDp08/H9py6DY+cfDw7kQNTGEj/rly3IgbNQA==",
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.3.5"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/node-fetch": {
@@ -693,6 +939,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/opmlparser": {
       "version": "0.8.0",
       "resolved": "https://registry.npmjs.org/opmlparser/-/opmlparser-0.8.0.tgz",
@@ -744,6 +999,33 @@
       "integrity": "sha512-A/AGNMFN3c8bOlvV9RreMdrv7jsmF9XIfDeCd87+I8RNg6s78BhJxMu69NEMHBSJFxKidViTEdruRwEk/WIKqA==",
       "license": "MIT"
     },
+    "node_modules/prebuild-install": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.3.tgz",
+      "integrity": "sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==",
+      "deprecated": "No longer maintained. Please contact the author of the relevant native addon; alternatives are available.",
+      "license": "MIT",
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^2.0.0",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
@@ -761,6 +1043,16 @@
       },
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/pump": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.4.tgz",
+      "integrity": "sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
       }
     },
     "node_modules/qs": {
@@ -800,6 +1092,21 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "license": "(BSD-2-Clause OR MIT OR Apache-2.0)",
+      "dependencies": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      },
+      "bin": {
+        "rc": "cli.js"
       }
     },
     "node_modules/readable-stream": {
@@ -854,6 +1161,18 @@
       "resolved": "https://registry.npmjs.org/sax/-/sax-0.6.1.tgz",
       "integrity": "sha512-8ip+qnRh7m8OEyvoM1JoSBzlrepp3ajVR8nqgrfTig+TewfyvTijl0am8/anFqgbcdz62ofEUKE1hHNDCdbeSQ==",
       "license": "BSD"
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "0.19.2",
@@ -978,6 +1297,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decompress-response": "^6.0.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
+      }
+    },
     "node_modules/statuses": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.2.tgz",
@@ -1010,6 +1374,69 @@
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
       "license": "MIT"
     },
+    "node_modules/strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.1.2.tgz",
+      "integrity": "sha512-vrN+B7DBIoTTZjnPNewwhx6cBA/H+IS7rfW68n7XxC1y7uoiGQBxaKzqucGUgavX15dJgiGztLJ8vxuEzwqBdA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/tar-fs": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.4.tgz",
+      "integrity": "sha512-mDAjwmZdh7LTT6pNleZ05Yt65HC3E+NiQzl672vQG38jIrehtJk/J3mNwIg+vShQPcLF/LV7CMnDW6vjj6sfYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
+      }
+    },
+    "node_modules/tar-stream": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
+        "fs-constants": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tar-stream/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1024,6 +1451,18 @@
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
       "license": "MIT"
+    },
+    "node_modules/tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      },
+      "engines": {
+        "node": "*"
+      }
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -1092,6 +1531,12 @@
         "tr46": "~0.0.3",
         "webidl-conversions": "^3.0.0"
       }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
     },
     "node_modules/xtend": {
       "version": "4.0.2",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "better-sqlite3": "^9.4.3",
     "cors": "^2.8.5",
     "express": "^4.18.2",
+    "fast-xml-parser": "^4.5.6",
     "multer": "^1.4.5-lts.1",
     "node-fetch": "^2.6.7",
     "opmlparser": "^0.8.0"

--- a/server.js
+++ b/server.js
@@ -6,6 +6,7 @@ const fs = require('fs');
 const crypto = require('crypto');
 const OPMLParser = require('opmlparser');
 const Database = require('better-sqlite3');
+const { XMLParser } = require('fast-xml-parser');
 
 const app = express();
 
@@ -52,6 +53,16 @@ function getDb() {
         name       TEXT,
         podcasts   TEXT NOT NULL,
         created_at TEXT NOT NULL
+      );
+      CREATE TABLE IF NOT EXISTS podcast_cache (
+        xmlurl               TEXT PRIMARY KEY,
+        description          TEXT,
+        artwork              TEXT,
+        categories           TEXT,
+        latest_episode_title TEXT,
+        latest_episode_date  TEXT,
+        frequency            TEXT,
+        fetched_at           TEXT NOT NULL
       )
     `);
   }
@@ -94,6 +105,165 @@ function updateProfileName(hash, name) {
     .prepare('UPDATE profiles SET name = ? WHERE hash = ?')
     .run(name, hash);
   return result.changes > 0;
+}
+
+// ---- Podcast metadata cache ----
+
+const CACHE_TTL_MS = 24 * 60 * 60 * 1000; // 24 hours
+
+function getCachedPodcast(xmlurl) {
+  return getDb().prepare('SELECT * FROM podcast_cache WHERE xmlurl = ?').get(xmlurl) || null;
+}
+
+function savePodcastCache(data) {
+  getDb().prepare(`
+    INSERT OR REPLACE INTO podcast_cache
+      (xmlurl, description, artwork, categories,
+       latest_episode_title, latest_episode_date, frequency, fetched_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(
+    data.xmlurl, data.description, data.artwork, data.categories,
+    data.latest_episode_title, data.latest_episode_date, data.frequency, data.fetched_at
+  );
+}
+
+function stripHtml(str) {
+  if (!str || typeof str !== 'string') return '';
+  return str
+    .replace(/<[^>]+>/g, '')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'")
+    .replace(/&nbsp;/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+function calculateFrequency(episodes) {
+  if (episodes.length < 2) return 'unknown';
+  const recent = episodes.slice(0, Math.min(6, episodes.length));
+  const gaps = [];
+  for (let i = 0; i < recent.length - 1; i++) {
+    const gap = (recent[i].date - recent[i + 1].date) / (1000 * 60 * 60 * 24);
+    if (gap >= 0) gaps.push(gap);
+  }
+  if (gaps.length === 0) return 'unknown';
+  const avgGap = gaps.reduce((a, b) => a + b, 0) / gaps.length;
+  if (avgGap < 1.5) return 'daily';
+  if (avgGap < 8) return 'weekly';
+  if (avgGap < 16) return 'biweekly';
+  if (avgGap < 35) return 'monthly';
+  if (avgGap < 90) return 'occasional';
+  return 'dormant';
+}
+
+function extractText(val) {
+  if (!val) return '';
+  if (typeof val === 'string') return val;
+  if (typeof val === 'object') return val['#text'] || val.__cdata || '';
+  return String(val);
+}
+
+async function fetchPodcastMetadata(xmlurl) {
+  // Return from cache if still fresh
+  const cached = getCachedPodcast(xmlurl);
+  if (cached && Date.now() - new Date(cached.fetched_at).getTime() < CACHE_TTL_MS) {
+    return { ...cached, categories: JSON.parse(cached.categories || '[]') };
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 10000);
+
+  let xml;
+  try {
+    const response = await fetch(xmlurl, {
+      signal: controller.signal,
+      headers: { 'User-Agent': 'PodcastPersonality/1.0' },
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    xml = await response.text();
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const parser = new XMLParser({
+    ignoreAttributes: false,
+    attributeNamePrefix: '@_',
+    cdataPropName: '__cdata',
+    isArray: (name) => ['item', 'entry', 'itunes:category', 'category'].includes(name),
+  });
+
+  const result = parser.parse(xml);
+  const channel = result?.rss?.channel || result?.feed;
+  if (!channel) throw new Error('No channel found in feed');
+
+  // Description
+  const rawDesc = channel['itunes:summary'] || channel.description || channel.subtitle || '';
+  const description = stripHtml(extractText(rawDesc)).slice(0, 500);
+
+  // Artwork
+  let artwork = '';
+  if (channel['itunes:image']?.['@_href']) {
+    artwork = channel['itunes:image']['@_href'];
+  } else if (channel.image?.url) {
+    artwork = extractText(channel.image.url);
+  }
+
+  // Categories
+  const categories = [];
+  const itunesCats = channel['itunes:category'];
+  if (Array.isArray(itunesCats)) {
+    itunesCats.forEach(c => { if (c['@_text']) categories.push(c['@_text']); });
+  } else if (itunesCats?.['@_text']) {
+    categories.push(itunesCats['@_text']);
+  }
+
+  // Episodes (RSS <item> or Atom <entry>)
+  const rawItems = channel.item || channel.entry || [];
+  const items = Array.isArray(rawItems) ? rawItems : [rawItems];
+  const episodes = items
+    .map(item => ({
+      title: extractText(item.title),
+      date: item.pubDate ? new Date(item.pubDate) : (item.updated ? new Date(item.updated) : null),
+    }))
+    .filter(ep => ep.date && !isNaN(ep.date.getTime()))
+    .sort((a, b) => b.date - a.date);
+
+  const latestEpisodeTitle = episodes[0]?.title || null;
+  const latestEpisodeDate = episodes[0]?.date?.toISOString() || null;
+  const frequency = calculateFrequency(episodes);
+
+  const metadata = {
+    xmlurl,
+    description,
+    artwork,
+    categories: JSON.stringify(categories),
+    latest_episode_title: latestEpisodeTitle,
+    latest_episode_date: latestEpisodeDate,
+    frequency,
+    fetched_at: new Date().toISOString(),
+  };
+
+  try { savePodcastCache(metadata); } catch (e) { console.error('Cache save failed:', e.message); }
+
+  return { ...metadata, categories };
+}
+
+function formatEnrichedMetadata(metadata) {
+  return {
+    description: metadata.description || null,
+    artwork: metadata.artwork || null,
+    categories: Array.isArray(metadata.categories)
+      ? metadata.categories
+      : JSON.parse(metadata.categories || '[]'),
+    latestEpisode: {
+      title: metadata.latest_episode_title || null,
+      date: metadata.latest_episode_date || null,
+    },
+    frequency: metadata.frequency || null,
+  };
 }
 
 // Health check
@@ -202,6 +372,45 @@ app.patch('/api/profiles/:hash', (req, res) => {
   }
 
   res.json({ name: trimmed });
+});
+
+// Enrich podcast metadata (with 24-hour cache per feed URL)
+app.post('/api/podcasts/enrich', async (req, res) => {
+  const { xmlurls } = req.body;
+  if (!Array.isArray(xmlurls) || xmlurls.length === 0) {
+    return res.status(400).json({ error: 'xmlurls must be a non-empty array' });
+  }
+
+  const urls = xmlurls.filter(u => typeof u === 'string').slice(0, 150);
+  const results = {};
+
+  // Return cached entries immediately; collect URLs that need live fetching
+  const toFetch = [];
+  for (const url of urls) {
+    const cached = getCachedPodcast(url);
+    if (cached && Date.now() - new Date(cached.fetched_at).getTime() < CACHE_TTL_MS) {
+      results[url] = formatEnrichedMetadata(cached);
+    } else {
+      toFetch.push(url);
+    }
+  }
+
+  // Fetch uncached feeds with limited concurrency (10 at a time)
+  const CONCURRENCY = 10;
+  for (let i = 0; i < toFetch.length; i += CONCURRENCY) {
+    const batch = toFetch.slice(i, i + CONCURRENCY);
+    await Promise.allSettled(batch.map(async (url) => {
+      try {
+        const metadata = await fetchPodcastMetadata(url);
+        results[url] = formatEnrichedMetadata(metadata);
+      } catch (err) {
+        console.error(`Enrich failed for ${url}:`, err.message);
+        results[url] = null;
+      }
+    }));
+  }
+
+  res.json(results);
 });
 
 // Serve React build in production


### PR DESCRIPTION
- Add fast-xml-parser dependency for RSS/Atom feed parsing
- Add podcast_cache SQLite table (keyed by feed URL, TTL 24h)
- Add fetchPodcastMetadata(): fetches description, artwork, categories,
  latest episode title/date, and publish frequency from each feed
- Add POST /api/podcasts/enrich endpoint: returns cached or live metadata
  for a batch of feed URLs, with concurrency limited to 10 at a time
- Update ProfilePage to call the enrich endpoint after loading a profile,
  showing artwork thumbnail, description (2-line clamp), category badges,
  latest episode title + relative date, and a colour-coded frequency badge

https://claude.ai/code/session_01CHVZcaps2VuomhDw7fY4xT