### PR TITLE
Fix profile build error: replace unsupported noOfLines with truncate

### DIFF
--- a/client/src/ProfilePage.tsx
+++ b/client/src/ProfilePage.tsx
@@ -270,7 +270,7 @@ function ProfilePage() {
 
                           {/* Latest episode */}
                           {meta?.latestEpisode?.title && (
-                            <Text fontSize="xs" color="gray.400" mt={1} noOfLines={1}>
+                            <Text fontSize="xs" color="gray.400" mt={1} truncate>
                               Latest: {meta.latestEpisode.title}
                               {meta.latestEpisode.date && (
                                 <> · {formatRelativeDate(meta.latestEpisode.date)}</>


### PR DESCRIPTION
Chakra UI v3 removed the `noOfLines` prop from `Text`. Replace it with
the `truncate` prop (single-line ellipsis) to fix the TypeScript
compilation error on the profile view.

https://claude.ai/code/session_018BVQucYUACrRB7WHuDJdyJ