### PR TITLE
Sort podcasts by latest episode date and link title/thumbnail to website

### DIFF
--- a/client/src/ProfilePage.tsx
+++ b/client/src/ProfilePage.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import {
   Box,
@@ -37,6 +37,7 @@ interface PodcastMetadata {
     date: string | null;
   };
   frequency: string | null;
+  websiteUrl: string | null;
 }
 
 function formatRelativeDate(isoDate: string): string {
@@ -80,6 +81,18 @@ function ProfilePage() {
 
   const [enriched, setEnriched] = useState<Record<string, PodcastMetadata | null>>({});
   const [enriching, setEnriching] = useState(false);
+
+  const sortedPodcasts = useMemo(() => {
+    if (!profile) return [];
+    return [...profile.podcasts].sort((a, b) => {
+      const dateA = enriched[a.xmlurl]?.latestEpisode?.date;
+      const dateB = enriched[b.xmlurl]?.latestEpisode?.date;
+      if (!dateA && !dateB) return 0;
+      if (!dateA) return 1;
+      if (!dateB) return -1;
+      return new Date(dateB).getTime() - new Date(dateA).getTime();
+    });
+  }, [profile, enriched]);
 
   useEffect(() => {
     axios.get(`/api/profiles/${hash}`)
@@ -203,22 +216,36 @@ function ProfilePage() {
 
             <Box w="100%">
               <ListRoot gap={4}>
-                {profile.podcasts.map((p, i) => {
+                {sortedPodcasts.map((p, i) => {
                   const meta = enriched[p.xmlurl];
+                  const href = meta?.websiteUrl || undefined;
                   return (
                     <ListItem key={i} listStyle="none">
                       <HStack gap={3} align="start">
                         {/* Artwork */}
                         {meta?.artwork && (
                           <Box flexShrink={0}>
-                            <img
-                              src={meta.artwork}
-                              alt=""
-                              width={64}
-                              height={64}
-                              style={{ borderRadius: 8, objectFit: 'cover', display: 'block' }}
-                              onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }}
-                            />
+                            {href ? (
+                              <a href={href} target="_blank" rel="noopener noreferrer">
+                                <img
+                                  src={meta.artwork}
+                                  alt=""
+                                  width={64}
+                                  height={64}
+                                  style={{ borderRadius: 8, objectFit: 'cover', display: 'block' }}
+                                  onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                                />
+                              </a>
+                            ) : (
+                              <img
+                                src={meta.artwork}
+                                alt=""
+                                width={64}
+                                height={64}
+                                style={{ borderRadius: 8, objectFit: 'cover', display: 'block' }}
+                                onError={e => { (e.target as HTMLImageElement).style.display = 'none'; }}
+                              />
+                            )}
                           </Box>
                         )}
 
@@ -226,7 +253,13 @@ function ProfilePage() {
                           {/* Title + frequency badge */}
                           <HStack justify="space-between" align="start" gap={2}>
                             <Text fontWeight="bold" style={{ overflowWrap: 'anywhere' }}>
-                              {p.title || p.xmlurl}
+                              {href ? (
+                                <a href={href} target="_blank" rel="noopener noreferrer" style={{ color: 'inherit', textDecoration: 'none' }}>
+                                  {p.title || p.xmlurl}
+                                </a>
+                              ) : (
+                                p.title || p.xmlurl
+                              )}
                             </Text>
                             {meta?.frequency && meta.frequency !== 'unknown' && (
                               <Badge

--- a/server.js
+++ b/server.js
@@ -65,6 +65,7 @@ function getDb() {
         fetched_at           TEXT NOT NULL
       )
     `);
+    try { _db.exec('ALTER TABLE podcast_cache ADD COLUMN website_url TEXT'); } catch (_) { /* column already exists */ }
   }
   return _db;
 }
@@ -119,11 +120,11 @@ function savePodcastCache(data) {
   getDb().prepare(`
     INSERT OR REPLACE INTO podcast_cache
       (xmlurl, description, artwork, categories,
-       latest_episode_title, latest_episode_date, frequency, fetched_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+       latest_episode_title, latest_episode_date, frequency, website_url, fetched_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     data.xmlurl, data.description, data.artwork, data.categories,
-    data.latest_episode_title, data.latest_episode_date, data.frequency, data.fetched_at
+    data.latest_episode_title, data.latest_episode_date, data.frequency, data.website_url, data.fetched_at
   );
 }
 
@@ -211,6 +212,19 @@ async function fetchPodcastMetadata(xmlurl) {
     artwork = extractText(channel.image.url);
   }
 
+  // Website URL
+  let websiteUrl = '';
+  if (channel.link) {
+    if (typeof channel.link === 'string') {
+      websiteUrl = channel.link;
+    } else if (Array.isArray(channel.link)) {
+      const altLink = channel.link.find(l => l['@_rel'] === 'alternate' || !l['@_rel']);
+      websiteUrl = altLink?.['@_href'] || channel.link[0]?.['@_href'] || '';
+    } else if (typeof channel.link === 'object') {
+      websiteUrl = channel.link['@_href'] || channel.link['#text'] || '';
+    }
+  }
+
   // Categories
   const categories = [];
   const itunesCats = channel['itunes:category'];
@@ -243,6 +257,7 @@ async function fetchPodcastMetadata(xmlurl) {
     latest_episode_title: latestEpisodeTitle,
     latest_episode_date: latestEpisodeDate,
     frequency,
+    website_url: websiteUrl,
     fetched_at: new Date().toISOString(),
   };
 
@@ -263,6 +278,7 @@ function formatEnrichedMetadata(metadata) {
       date: metadata.latest_episode_date || null,
     },
     frequency: metadata.frequency || null,
+    websiteUrl: metadata.website_url || null,
   };
 }
 


### PR DESCRIPTION
- Extract website URL from RSS/Atom feed channel.link in server enrichment
- Add website_url column to podcast_cache table (with migration for existing DBs)
- Include websiteUrl in the enriched metadata API response
- Sort podcast list by latestEpisode.date descending (most recent first)
- Wrap podcast thumbnail and title in anchor tags linking to the podcast website

https://claude.ai/code/session_01HWPW82u81GcUFrgQkCZ5Vv