### PR TITLE
Add podcast personality analysis panel to profile view

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -7,3 +7,7 @@ NODE_ENV=development
 # Comma-separated list of allowed CORS origins (production only).
 # Leave unset when frontend is served from the same origin (recommended).
 # ALLOWED_ORIGINS=https://your-app.up.railway.app
+
+# Anthropic API key for AI personality analysis (optional).
+# Without this the category/frequency stats still display; the AI section is skipped.
+# ANTHROPIC_API_KEY=sk-ant-...

--- a/client/src/ProfilePage.tsx
+++ b/client/src/ProfilePage.tsx
@@ -40,6 +40,21 @@ interface PodcastMetadata {
   websiteUrl: string | null;
 }
 
+interface PersonalityAnalysis {
+  archetype: string;
+  summary: string;
+  traits: {
+    openness: number;
+    conscientiousness: number;
+    extraversion: number;
+    agreeableness: number;
+    neuroticism: number;
+  };
+  traitNotes: Record<string, string>;
+  interests: string[];
+  listeningStyle: string;
+}
+
 function formatRelativeDate(isoDate: string): string {
   const date = new Date(isoDate);
   const days = Math.floor((Date.now() - date.getTime()) / (1000 * 60 * 60 * 24));
@@ -67,7 +82,176 @@ const FREQUENCY_LABEL: Record<string, string> = {
   monthly: 'Monthly',
   occasional: 'Occasional',
   dormant: 'Dormant',
+  unknown: 'Unknown',
 };
+
+const FREQUENCY_EMOJI: Record<string, string> = {
+  daily: '🔥',
+  weekly: '📅',
+  biweekly: '📆',
+  monthly: '🗓️',
+  occasional: '🌊',
+  dormant: '💤',
+  unknown: '❓',
+};
+
+// Episodes per week for each cadence bucket
+const FREQUENCY_WEEKLY_RATE: Record<string, number> = {
+  daily: 7,
+  weekly: 1,
+  biweekly: 0.5,
+  monthly: 0.25,
+  occasional: 0.1,
+  dormant: 0,
+  unknown: 0,
+};
+
+const FREQUENCY_ORDER = ['daily', 'weekly', 'biweekly', 'monthly', 'occasional', 'dormant', 'unknown'];
+
+const CATEGORY_EMOJIS: Record<string, string> = {
+  'Technology': '💻',
+  'Business': '💼',
+  'News': '📰',
+  'News Commentary': '🗣️',
+  'Science': '🔬',
+  'Natural Sciences': '🧪',
+  'Social Sciences': '🧠',
+  'Arts': '🎨',
+  'Visual Arts': '🖼️',
+  'Performing Arts': '🎭',
+  'Comedy': '😄',
+  'Comedy Interviews': '🎤',
+  'Stand-Up': '🎙️',
+  'Health & Fitness': '🏃',
+  'Fitness': '💪',
+  'Medicine': '🩺',
+  'Mental Health': '🧘',
+  'Nutrition': '🥗',
+  'Alternative Health': '🌿',
+  'Society & Culture': '🌍',
+  'Society': '🌍',
+  'Culture': '🎭',
+  'Education': '📚',
+  'Self-Improvement': '🌱',
+  'Language Learning': '🗣️',
+  'How To': '🔧',
+  'Sports': '⚽',
+  'Soccer': '⚽',
+  'Football': '🏈',
+  'Basketball': '🏀',
+  'Baseball': '⚾',
+  'Cricket': '🏏',
+  'Racing': '🏎️',
+  'Rugby': '🏉',
+  'Swimming': '🏊',
+  'Tennis': '🎾',
+  'Golf': '⛳',
+  'True Crime': '🔍',
+  'History': '📜',
+  'Music': '🎵',
+  'Music History': '🎼',
+  'Music Interviews': '🎤',
+  'Religion & Spirituality': '🙏',
+  'Christianity': '✝️',
+  'Islam': '☪️',
+  'Judaism': '✡️',
+  'Buddhism': '☸️',
+  'Spirituality': '✨',
+  'Government': '🏛️',
+  'Politics': '🗳️',
+  'Fiction': '📖',
+  'Science Fiction': '🚀',
+  'Drama': '🎭',
+  'Horror': '👻',
+  'Leisure': '🎮',
+  'Games': '🎮',
+  'Video Games': '🕹️',
+  'Hobbies': '🔧',
+  'Animation': '🎨',
+  'Anime': '🍜',
+  'Kids & Family': '👨‍👩‍👧',
+  'Kids': '👶',
+  'Parenting': '👨‍👩‍👧‍👦',
+  'Stories for Kids': '📖',
+  'Travel': '✈️',
+  'Outdoors': '🏔️',
+  'Wilderness': '🌲',
+  'Food': '🍕',
+  'TV & Film': '🎬',
+  'Film History': '🎥',
+  'Film Interviews': '🎬',
+  'Documentary': '📽️',
+  'Books': '📚',
+  'Design': '✏️',
+  'Fashion & Beauty': '👗',
+  'Entrepreneurship': '🚀',
+  'Investing': '📈',
+  'Marketing': '📢',
+  'Management': '👔',
+  'Finance': '💰',
+  'Personal Finance': '💵',
+  'Careers': '📋',
+  'Pets & Animals': '🐾',
+  'Fantasy Sports': '🏆',
+  'Relationships': '❤️',
+  'Sexuality': '💛',
+  'Philosophy': '💭',
+  'Personal Journals': '📓',
+  'Interviews': '🎙️',
+  'Language': '🌐',
+  'Astronomy': '🔭',
+  'Environment': '🌿',
+  'Healthcare': '🏥',
+  'Non-Profit': '🤝',
+};
+
+function getCategoryEmoji(category: string): string {
+  if (CATEGORY_EMOJIS[category]) return CATEGORY_EMOJIS[category];
+  // Fuzzy match on first word
+  const first = category.split(/[\s&]/)[0];
+  const match = Object.entries(CATEGORY_EMOJIS).find(([k]) => k.startsWith(first));
+  return match ? match[1] : '🎙️';
+}
+
+const TRAIT_LABELS: Record<string, string> = {
+  openness: 'Openness',
+  conscientiousness: 'Conscientiousness',
+  extraversion: 'Extraversion',
+  agreeableness: 'Agreeableness',
+  neuroticism: 'Neuroticism',
+};
+
+const TRAIT_EMOJIS: Record<string, string> = {
+  openness: '🔭',
+  conscientiousness: '📋',
+  extraversion: '🌟',
+  agreeableness: '🤝',
+  neuroticism: '🌊',
+};
+
+const TRAIT_COLORS: Record<string, string> = {
+  openness: 'var(--chakra-colors-purple-400)',
+  conscientiousness: 'var(--chakra-colors-green-400)',
+  extraversion: 'var(--chakra-colors-orange-400)',
+  agreeableness: 'var(--chakra-colors-teal-400)',
+  neuroticism: 'var(--chakra-colors-red-400)',
+};
+
+const TRAIT_ORDER: (keyof PersonalityAnalysis['traits'])[] = [
+  'openness', 'conscientiousness', 'extraversion', 'agreeableness', 'neuroticism',
+];
+
+function ProgressBar({ ratio, color }: { ratio: number; color: string }) {
+  return (
+    <Box h="7px" bg="gray.100" borderRadius="full" overflow="hidden">
+      <Box
+        h="7px"
+        borderRadius="full"
+        style={{ width: `${Math.min(100, Math.max(0, ratio * 100))}%`, background: color, transition: 'width 0.6s ease' }}
+      />
+    </Box>
+  );
+}
 
 function ProfilePage() {
   const { hash } = useParams<{ hash: string }>();
@@ -82,6 +266,9 @@ function ProfilePage() {
   const [enriched, setEnriched] = useState<Record<string, PodcastMetadata | null>>({});
   const [enriching, setEnriching] = useState(false);
 
+  const [personality, setPersonality] = useState<PersonalityAnalysis | null>(null);
+  const [analyzing, setAnalyzing] = useState(false);
+
   const sortedPodcasts = useMemo(() => {
     if (!profile) return [];
     return [...profile.podcasts].sort((a, b) => {
@@ -94,12 +281,44 @@ function ProfilePage() {
     });
   }, [profile, enriched]);
 
+  // Category ratios: count how many podcasts appear in each category
+  const categoryRatios = useMemo(() => {
+    const enrichedList = Object.values(enriched).filter(Boolean) as PodcastMetadata[];
+    if (enrichedList.length === 0) return [];
+    const counts: Record<string, number> = {};
+    for (const meta of enrichedList) {
+      for (const cat of meta.categories) {
+        counts[cat] = (counts[cat] || 0) + 1;
+      }
+    }
+    return Object.entries(counts)
+      .map(([category, count]) => ({ category, count, ratio: count / enrichedList.length }))
+      .sort((a, b) => b.count - a.count);
+  }, [enriched]);
+
+  // Frequency distribution: count per bucket
+  const frequencyDistribution = useMemo(() => {
+    const dist: Record<string, number> = {};
+    for (const meta of Object.values(enriched)) {
+      if (!meta?.frequency) continue;
+      dist[meta.frequency] = (dist[meta.frequency] || 0) + 1;
+    }
+    return dist;
+  }, [enriched]);
+
+  // Estimated new episodes per week across the library
+  const weeklyEpisodeRate = useMemo(() => {
+    return Object.entries(frequencyDistribution).reduce((sum, [freq, count]) => {
+      return sum + (FREQUENCY_WEEKLY_RATE[freq] ?? 0) * count;
+    }, 0);
+  }, [frequencyDistribution]);
+
   useEffect(() => {
     axios.get(`/api/profiles/${hash}`)
-      .then(res => {
+      .then(async res => {
         setProfile(res.data);
         setNameInput(res.data.name || '');
-        enrichPodcasts(res.data.podcasts);
+        await enrichPodcasts(res.data.podcasts);
       })
       .catch(err => {
         if (err.response?.status === 404) {
@@ -115,15 +334,48 @@ function ProfilePage() {
   const enrichPodcasts = async (podcasts: Podcast[]) => {
     if (podcasts.length === 0) return;
     setEnriching(true);
+    let enrichedData: Record<string, PodcastMetadata | null> = {};
     try {
       const res = await axios.post('/api/podcasts/enrich', {
         xmlurls: podcasts.map(p => p.xmlurl),
       });
-      setEnriched(res.data);
+      enrichedData = res.data;
+      setEnriched(enrichedData);
     } catch (err) {
       console.error('Failed to enrich podcasts', err);
     } finally {
       setEnriching(false);
+    }
+    // Trigger personality analysis once enrichment data is available
+    if (Object.keys(enrichedData).length > 0) {
+      runPersonalityAnalysis(podcasts, enrichedData);
+    }
+  };
+
+  const runPersonalityAnalysis = async (
+    podcasts: Podcast[],
+    enrichedData: Record<string, PodcastMetadata | null>,
+  ) => {
+    const podcastSummary = podcasts.map(p => ({
+      title: p.title,
+      categories: enrichedData[p.xmlurl]?.categories ?? [],
+      frequency: enrichedData[p.xmlurl]?.frequency ?? 'unknown',
+    }));
+    // Need at least a few podcasts with category data for a meaningful analysis
+    const withCategories = podcastSummary.filter(p => p.categories.length > 0);
+    if (withCategories.length < 3) return;
+
+    setAnalyzing(true);
+    try {
+      const res = await axios.post('/api/personality', { podcastSummary });
+      if (res.data.personality) setPersonality(res.data.personality);
+    } catch (err: any) {
+      // 503 = no API key configured — silently skip
+      if (err.response?.status !== 503) {
+        console.error('Personality analysis failed', err);
+      }
+    } finally {
+      setAnalyzing(false);
     }
   };
 
@@ -157,6 +409,8 @@ function ProfilePage() {
       toaster.create({ title: 'Link copied!', type: 'success', duration: 1500 });
     }
   };
+
+  const showAnalysisPanel = !enriching && (categoryRatios.length > 0 || Object.keys(frequencyDistribution).length > 0);
 
   return (
     <Box minH="100vh" bg="gray.50" py={10} px={4}>
@@ -214,6 +468,158 @@ function ProfilePage() {
 
             <Button colorPalette="blue" onClick={handleShare} w="100%">Share This Profile</Button>
 
+            {/* ── Personality Analysis Panel ── */}
+            {showAnalysisPanel && (
+              <Box w="100%" borderRadius="xl" overflow="hidden" borderWidth="1px" borderColor="gray.200">
+                {/* Panel header */}
+                <Box px={5} py={3} bg="gray.50" borderBottomWidth="1px" borderColor="gray.200">
+                  <HStack justify="space-between">
+                    <Text fontWeight="bold" fontSize="md">🎙️ Personality Insights</Text>
+                    {analyzing && (
+                      <HStack gap={1.5}>
+                        <Spinner size="xs" />
+                        <Text fontSize="xs" color="gray.400">Analysing…</Text>
+                      </HStack>
+                    )}
+                  </HStack>
+                </Box>
+
+                <Box p={5}>
+                  <VStack gap={5} align="stretch">
+
+                    {/* AI Archetype card */}
+                    {personality && (
+                      <Box
+                        p={4}
+                        bg="blue.50"
+                        borderRadius="lg"
+                        borderLeftWidth="4px"
+                        borderLeftColor="blue.400"
+                      >
+                        <Text fontWeight="bold" fontSize="lg" mb={1}>
+                          🧠 {personality.archetype}
+                        </Text>
+                        <Text fontSize="sm" color="gray.700" lineHeight="tall">
+                          {personality.summary}
+                        </Text>
+                        {personality.listeningStyle && (
+                          <Text fontSize="xs" color="blue.600" mt={2} fontStyle="italic">
+                            🎧 {personality.listeningStyle}
+                          </Text>
+                        )}
+                      </Box>
+                    )}
+
+                    {/* ── Category breakdown ── */}
+                    {categoryRatios.length > 0 && (
+                      <Box>
+                        <Text fontWeight="semibold" fontSize="sm" color="gray.600" mb={3}>
+                          📊 Content Mix
+                        </Text>
+                        <VStack gap={2} align="stretch">
+                          {categoryRatios.slice(0, 8).map(({ category, count, ratio }) => (
+                            <Box key={category}>
+                              <HStack justify="space-between" mb={1}>
+                                <Text fontSize="sm">
+                                  {getCategoryEmoji(category)} {category}
+                                </Text>
+                                <Text fontSize="xs" color="gray.500" fontWeight="medium">
+                                  {Math.round(ratio * 100)}% &nbsp;
+                                  <Text as="span" color="gray.400">({count})</Text>
+                                </Text>
+                              </HStack>
+                              <ProgressBar ratio={ratio} color="var(--chakra-colors-blue-400)" />
+                            </Box>
+                          ))}
+                          {categoryRatios.length > 8 && (
+                            <Text fontSize="xs" color="gray.400">
+                              +{categoryRatios.length - 8} more categories
+                            </Text>
+                          )}
+                        </VStack>
+                      </Box>
+                    )}
+
+                    {/* ── Frequency / cadence ── */}
+                    {Object.keys(frequencyDistribution).length > 0 && (
+                      <Box>
+                        <Text fontWeight="semibold" fontSize="sm" color="gray.600" mb={3}>
+                          ⏱️ Content Cadence
+                        </Text>
+                        <HStack flexWrap="wrap" gap={2} mb={2}>
+                          {FREQUENCY_ORDER.filter(f => frequencyDistribution[f]).map(freq => (
+                            <Badge
+                              key={freq}
+                              colorPalette={FREQUENCY_PALETTE[freq] ?? 'gray'}
+                              variant="subtle"
+                              size="md"
+                            >
+                              {FREQUENCY_EMOJI[freq]} {frequencyDistribution[freq]} {FREQUENCY_LABEL[freq] ?? freq}
+                            </Badge>
+                          ))}
+                        </HStack>
+                        {weeklyEpisodeRate > 0 && (
+                          <Text fontSize="xs" color="gray.500">
+                            📬 Your library generates ~<Text as="span" fontWeight="semibold">{Math.round(weeklyEpisodeRate)}</Text> new episodes per week
+                          </Text>
+                        )}
+                      </Box>
+                    )}
+
+                    {/* ── Big Five traits ── */}
+                    {personality?.traits && (
+                      <Box>
+                        <Text fontWeight="semibold" fontSize="sm" color="gray.600" mb={3}>
+                          🌊 Big Five Personality Traits
+                        </Text>
+                        <VStack gap={3} align="stretch">
+                          {TRAIT_ORDER.map(trait => {
+                            const score = personality.traits[trait];
+                            return (
+                              <Box key={trait}>
+                                <HStack justify="space-between" mb={1}>
+                                  <Text fontSize="sm">
+                                    {TRAIT_EMOJIS[trait]} {TRAIT_LABELS[trait]}
+                                  </Text>
+                                  <Text fontSize="xs" color="gray.500" fontWeight="medium">
+                                    {score}%
+                                  </Text>
+                                </HStack>
+                                <ProgressBar ratio={score / 100} color={TRAIT_COLORS[trait]} />
+                                {personality.traitNotes?.[trait] && (
+                                  <Text fontSize="xs" color="gray.500" mt={0.5} lineHeight="short">
+                                    {personality.traitNotes[trait]}
+                                  </Text>
+                                )}
+                              </Box>
+                            );
+                          })}
+                        </VStack>
+                      </Box>
+                    )}
+
+                    {/* ── Key interests ── */}
+                    {personality?.interests && personality.interests.length > 0 && (
+                      <Box>
+                        <Text fontWeight="semibold" fontSize="sm" color="gray.600" mb={2}>
+                          ✨ Key Interests
+                        </Text>
+                        <HStack flexWrap="wrap" gap={2}>
+                          {personality.interests.map((interest, i) => (
+                            <Badge key={i} colorPalette="purple" variant="outline" size="sm">
+                              {interest}
+                            </Badge>
+                          ))}
+                        </HStack>
+                      </Box>
+                    )}
+
+                  </VStack>
+                </Box>
+              </Box>
+            )}
+
+            {/* ── Podcast list ── */}
             <Box w="100%">
               <ListRoot gap={4}>
                 {sortedPodcasts.map((p, i) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@anthropic-ai/sdk": "^0.88.0",
         "better-sqlite3": "^9.4.3",
         "cors": "^2.8.5",
         "express": "^4.18.2",
@@ -19,6 +20,35 @@
       },
       "engines": {
         "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.88.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.88.0.tgz",
+      "integrity": "sha512-QQOtB5U9ZBJQj6y1ICmDZl14LWa4JCiJRoihI+0yuZ4OjbONrakP0yLwPv4DJFb3VYCtQM31bTOpCBMs2zghPw==",
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.2.tgz",
+      "integrity": "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
       }
     },
     "node_modules/accepts": {
@@ -725,6 +755,19 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
       "license": "MIT"
+    },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -1450,6 +1493,12 @@
       "version": "0.0.3",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
       "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
       "license": "MIT"
     },
     "node_modules/tunnel-agent": {

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "postinstall": "npm run build"
   },
   "dependencies": {
+    "@anthropic-ai/sdk": "^0.88.0",
     "better-sqlite3": "^9.4.3",
     "cors": "^2.8.5",
     "express": "^4.18.2",

--- a/server.js
+++ b/server.js
@@ -7,6 +7,7 @@ const crypto = require('crypto');
 const OPMLParser = require('opmlparser');
 const Database = require('better-sqlite3');
 const { XMLParser } = require('fast-xml-parser');
+const Anthropic = require('@anthropic-ai/sdk');
 
 const app = express();
 
@@ -427,6 +428,128 @@ app.post('/api/podcasts/enrich', async (req, res) => {
   }
 
   res.json(results);
+});
+
+// Personality analysis endpoint — uses Claude to derive Big Five traits from podcast categories
+const PERSONALITY_SYSTEM_PROMPT = `You are an expert personality psychologist who analyses media consumption patterns to infer personality profiles. You apply the Big Five (OCEAN) personality model and Uses-and-Gratifications theory to provide accurate, nuanced insights based on podcast listening habits.
+
+Your analysis is always:
+- Evidence-based and grounded in media-psychology research
+- Specific and insightful, never generic
+- Balanced and non-judgmental
+- Probabilistic — patterns suggest tendencies, not certainties
+
+Respond with valid JSON only. No markdown, no explanations outside the JSON.`;
+
+app.post('/api/personality', async (req, res) => {
+  const { podcastSummary } = req.body;
+  if (!Array.isArray(podcastSummary) || podcastSummary.length === 0) {
+    return res.status(400).json({ error: 'podcastSummary must be a non-empty array' });
+  }
+
+  // Sanitise input
+  const summary = podcastSummary
+    .filter(p => p && typeof p.title === 'string')
+    .slice(0, 200)
+    .map(p => ({
+      title: String(p.title).slice(0, 200),
+      categories: Array.isArray(p.categories) ? p.categories.slice(0, 5).map(c => String(c).slice(0, 80)) : [],
+      frequency: typeof p.frequency === 'string' ? p.frequency : 'unknown',
+    }));
+
+  if (summary.length === 0) {
+    return res.status(400).json({ error: 'No valid podcast data provided' });
+  }
+
+  const apiKey = process.env.ANTHROPIC_API_KEY;
+  if (!apiKey) {
+    return res.status(503).json({ error: 'AI analysis unavailable — ANTHROPIC_API_KEY not configured' });
+  }
+
+  try {
+    const client = new Anthropic({ apiKey });
+
+    // Build concise summary for the prompt
+    const categoryCounts = {};
+    for (const p of summary) {
+      for (const cat of p.categories) {
+        categoryCounts[cat] = (categoryCounts[cat] || 0) + 1;
+      }
+    }
+    const topCategories = Object.entries(categoryCounts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 12)
+      .map(([cat, count]) => `${cat} (${Math.round(count / summary.length * 100)}%)`)
+      .join(', ');
+
+    const freqCounts = {};
+    for (const p of summary) {
+      freqCounts[p.frequency] = (freqCounts[p.frequency] || 0) + 1;
+    }
+    const freqSummary = Object.entries(freqCounts)
+      .sort((a, b) => b[1] - a[1])
+      .map(([f, n]) => `${n} ${f}`)
+      .join(', ');
+
+    const titles = summary.slice(0, 30).map(p => p.title).filter(Boolean).join(', ');
+
+    const userPrompt = `Analyse this podcast listening profile:
+Total podcasts: ${summary.length}
+Top categories (% of library): ${topCategories || 'uncategorised'}
+Publishing frequency breakdown: ${freqSummary}
+Sample podcast titles: ${titles}
+
+Return a JSON object with this exact structure:
+{
+  "archetype": "2-4 word evocative title, e.g. 'The Analytical Explorer'",
+  "summary": "2-3 sentences describing personality inferred from listening choices",
+  "traits": {
+    "openness": <integer 0-100>,
+    "conscientiousness": <integer 0-100>,
+    "extraversion": <integer 0-100>,
+    "agreeableness": <integer 0-100>,
+    "neuroticism": <integer 0-100>
+  },
+  "traitNotes": {
+    "openness": "one sentence explaining this score",
+    "conscientiousness": "one sentence explaining this score",
+    "extraversion": "one sentence explaining this score",
+    "agreeableness": "one sentence explaining this score",
+    "neuroticism": "one sentence explaining this score"
+  },
+  "interests": ["interest 1", "interest 2", "interest 3", "interest 4", "interest 5"],
+  "listeningStyle": "one sentence about how they engage with podcast content"
+}`;
+
+    const message = await client.messages.create({
+      model: 'claude-sonnet-4-6',
+      max_tokens: 1024,
+      system: [
+        {
+          type: 'text',
+          text: PERSONALITY_SYSTEM_PROMPT,
+          cache_control: { type: 'ephemeral' },
+        },
+      ],
+      messages: [{ role: 'user', content: userPrompt }],
+    });
+
+    const raw = message.content[0]?.text || '';
+    let personality;
+    try {
+      const cleaned = raw.replace(/^```json\s*|\s*```$/g, '').trim();
+      personality = JSON.parse(cleaned);
+    } catch {
+      const match = raw.match(/\{[\s\S]+\}/);
+      if (match) personality = JSON.parse(match[0]);
+      else throw new Error('Could not parse AI response as JSON');
+    }
+
+    res.json({ personality });
+  } catch (err) {
+    console.error('Personality analysis failed:', err.message);
+    res.status(500).json({ error: 'AI analysis failed: ' + err.message });
+  }
 });
 
 // Serve React build in production


### PR DESCRIPTION
- Install @anthropic-ai/sdk (v0.88.0) for AI-powered personality profiling
- Add POST /api/personality endpoint: computes category ratios & frequency
  distribution from enriched podcast data, then calls Claude (claude-sonnet-4-6)
  with prompt-cached system prompt to derive Big Five (OCEAN) personality traits,
  a named archetype, key interests, and a listening-style summary
- Gracefully skips AI analysis when ANTHROPIC_API_KEY is not configured
- Update ProfilePage.tsx with a personality insights panel shown at the top of
  the profile, featuring:
  - 📊 Category Mix: per-category ratio bars with emoji icons
  - ⏱️ Content Cadence: frequency distribution badges + estimated episodes/week
  - 🧠 AI Archetype card with summary and listening style (when API key present)
  - 🌊 Big Five trait bars (Openness, Conscientiousness, Extraversion,
    Agreeableness, Neuroticism) with one-line explanations per trait
  - ✨ Key Interests badges
- All computed stats appear immediately after enrichment; AI card loads async
- Document ANTHROPIC_API_KEY in .env.example

https://claude.ai/code/session_018J6dLJzKQcX7EdesEtBoEr