### PR TITLE
Add dynamic OpenGraph tags and improve profile sharing

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -5,39 +5,16 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta
-      name="description"
-      content="Web site created using create-react-app"
-    />
+    <meta name="description" content="Discover what your podcast subscriptions say about your personality. Upload your OPML and get an instant profile." />
+    <meta property="og:title" content="Podcast Personality" />
+    <meta property="og:description" content="Discover what your podcast subscriptions say about your personality." />
+    <meta property="og:type" content="website" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
-    <!--
-      manifest.json provides metadata used when your web app is installed on a
-      user's mobile device or desktop. See https://developers.google.com/web/fundamentals/web-app-manifest/
-    -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <!--
-      Notice the use of %PUBLIC_URL% in the tags above.
-      It will be replaced with the URL of the `public` folder during the build.
-      Only files inside the `public` folder can be referenced from the HTML.
-
-      Unlike "/favicon.ico" or "favicon.ico", "%PUBLIC_URL%/favicon.ico" will
-      work correctly both with client-side routing and a non-root public URL.
-      Learn how to configure a non-root public URL by running `npm run build`.
-    -->
-    <title>React App</title>
+    <title>Podcast Personality</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>
     <div id="root"></div>
-    <!--
-      This HTML file is a template.
-      If you open it directly in the browser, you will see an empty page.
-
-      You can add webfonts, meta tags, or analytics to this file.
-      The build step will place the bundled scripts into the <body> tag.
-
-      To begin the development, run `npm start` or `yarn start`.
-      To create a production bundle, use `npm run build` or `yarn build`.
-    -->
   </body>
 </html>

--- a/client/public/manifest.json
+++ b/client/public/manifest.json
@@ -1,6 +1,6 @@
 {
-  "short_name": "React App",
-  "name": "Create React App Sample",
+  "short_name": "Podcast Personality",
+  "name": "Podcast Personality",
   "icons": [
     {
       "src": "favicon.ico",

--- a/client/src/ProfilePage.tsx
+++ b/client/src/ProfilePage.tsx
@@ -434,32 +434,34 @@ function ProfilePage() {
               {profile.name ? `${profile.name}'s Profile` : 'Podcast Profile'}
             </Text>
 
-            {/* Name form */}
-            <Box w="100%" p={16} bg="gray.0" style={{ borderRadius: 8 }}>
-              <Text size="sm" fw={600} mb={8} c="gray.6">
-                {profile.name ? 'Your name' : 'Set your name'}
-              </Text>
-              <Group>
-                <TextInput
-                  value={nameInput}
-                  onChange={e => setNameInput(e.target.value)}
-                  placeholder="Enter your name"
-                  size="sm"
-                  style={{ flex: 1 }}
-                  onKeyDown={e => e.key === 'Enter' && handleSaveName()}
-                />
-                <Button
-                  size="sm"
-                  variant="gradient"
-                  gradient={{ from: 'blue', to: 'cyan' }}
-                  onClick={handleSaveName}
-                  loading={savingName}
-                  disabled={!nameInput.trim() || savingName}
-                >
-                  Save
-                </Button>
-              </Group>
-            </Box>
+            {/* Name form — only shown until a name has been saved */}
+            {!profile.name && (
+              <Box w="100%" p={16} bg="gray.0" style={{ borderRadius: 8 }}>
+                <Text size="sm" fw={600} mb={8} c="gray.6">
+                  Set your name
+                </Text>
+                <Group>
+                  <TextInput
+                    value={nameInput}
+                    onChange={e => setNameInput(e.target.value)}
+                    placeholder="Enter your name"
+                    size="sm"
+                    style={{ flex: 1 }}
+                    onKeyDown={e => e.key === 'Enter' && handleSaveName()}
+                  />
+                  <Button
+                    size="sm"
+                    variant="gradient"
+                    gradient={{ from: 'blue', to: 'cyan' }}
+                    onClick={handleSaveName}
+                    loading={savingName}
+                    disabled={!nameInput.trim() || savingName}
+                  >
+                    Save
+                  </Button>
+                </Group>
+              </Box>
+            )}
 
             <Group w="100%" justify="space-between" align="center">
               <Text c="gray.5">{profile.podcasts.length} podcasts</Text>

--- a/server.js
+++ b/server.js
@@ -556,6 +556,43 @@ Return a JSON object with this exact structure:
 if (process.env.NODE_ENV === 'production') {
   const clientBuildPath = path.join(__dirname, 'client', 'build');
   app.use(express.static(clientBuildPath));
+
+  // Inject dynamic OpenGraph tags for shareable profile pages
+  app.get('/p/:hash', (req, res) => {
+    const { hash } = req.params;
+    const profile = loadProfile(hash);
+    const indexPath = path.join(clientBuildPath, 'index.html');
+    const html = fs.readFileSync(indexPath, 'utf8');
+
+    let title = 'Podcast Personality';
+    let description = 'Discover what your podcast subscriptions say about your personality.';
+
+    if (profile) {
+      const displayName = profile.name ? profile.name : 'Someone';
+      const podcastCount = profile.podcasts.length;
+      title = profile.name ? `${profile.name}'s Podcast Profile` : 'A Podcast Personality Profile';
+      description = `${displayName} listens to ${podcastCount} podcast${podcastCount !== 1 ? 's' : ''}. See their personality profile and what their listening taste reveals about them.`;
+    }
+
+    const escape = s => s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+    const injected = html.replace(
+      '<meta property="og:title" content="Podcast Personality" />',
+      `<meta property="og:title" content="${escape(title)}" />\n    <meta property="og:description" content="${escape(description)}" />`,
+    ).replace(
+      '<meta property="og:description" content="Discover what your podcast subscriptions say about your personality." />',
+      '',
+    ).replace(
+      '<meta name="description" content="Discover what your podcast subscriptions say about your personality. Upload your OPML and get an instant profile." />',
+      `<meta name="description" content="${escape(description)}" />`,
+    ).replace(
+      '<title>Podcast Personality</title>',
+      `<title>${escape(title)}</title>`,
+    );
+
+    res.setHeader('Content-Type', 'text/html');
+    res.send(injected);
+  });
+
   app.get('*', (req, res) => {
     res.sendFile(path.join(clientBuildPath, 'index.html'));
   });


### PR DESCRIPTION
## Summary
This PR enhances profile sharing capabilities by implementing dynamic OpenGraph meta tags for shareable profile pages and improves the initial user experience by hiding the name form after it's been set.

## Key Changes

- **Dynamic OpenGraph tags for profile pages**: Added server-side rendering of meta tags for `/p/:hash` routes that inject personalized title and description based on the profile data (name and podcast count)
- **Hide name form after initial setup**: Modified the ProfilePage to conditionally render the name input form only when no name has been set, reducing clutter for returning users
- **Updated HTML metadata**: 
  - Replaced placeholder meta tags with proper descriptions for the Podcast Personality app
  - Added OpenGraph protocol tags (og:title, og:description, og:type) for better social media sharing
  - Updated page title from "React App" to "Podcast Personality"
- **Updated manifest.json**: Changed app name and short name from generic "React App" to "Podcast Personality"

## Implementation Details

The server-side OpenGraph injection:
- Loads the profile data using the hash parameter
- Generates contextual title and description (e.g., "John's Podcast Profile" with podcast count)
- Properly escapes HTML entities in dynamic content
- Replaces placeholder meta tags in the built index.html with personalized versions
- Falls back to default messaging if profile data is unavailable

This enables proper preview cards when profile links are shared on social media platforms.

https://claude.ai/code/session_0195Ck5rGXHbouyQdmqjiuQg