### PR TITLE
Add homepage intro content and rename app to Podnality

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -5,13 +5,13 @@
     <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
-    <meta name="description" content="Discover what your podcast subscriptions say about your personality. Upload your OPML and get an instant profile." />
-    <meta property="og:title" content="Podcast Personality" />
-    <meta property="og:description" content="Discover what your podcast subscriptions say about your personality." />
+    <meta name="description" content="What do your podcast subscriptions say about your personality? Upload your OPML and get an instant shareable profile — no AI, just number crunching." />
+    <meta property="og:title" content="Podnality" />
+    <meta property="og:description" content="What do your podcast subscriptions say about your personality? Find out with Podnality." />
     <meta property="og:type" content="website" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
-    <title>Podcast Personality</title>
+    <title>Podnality</title>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/client/src/UploadPage.tsx
+++ b/client/src/UploadPage.tsx
@@ -7,6 +7,7 @@ import {
   Button,
   Text,
   Loader,
+  Divider,
 } from '@mantine/core';
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
@@ -96,8 +97,31 @@ function UploadPage() {
 
   return (
     <Box mih="100vh" bg="gray.0" py={40} px={16}>
-      <Stack gap={24} maw={480} mx="auto" bg="white" p={32} style={{ borderRadius: 12, boxShadow: '0 1px 8px rgba(0,0,0,0.08)' }}>
-        <Title order={1} size="h2">Upload Your Podcast OPML</Title>
+      <Stack gap={24} maw={600} mx="auto" bg="white" p={32} style={{ borderRadius: 12, boxShadow: '0 1px 8px rgba(0,0,0,0.08)' }}>
+        <Stack gap={12}>
+          <Title order={1} size="h2">What do your podcast subscriptions say about your personality?</Title>
+          <Text c="gray.7">
+            Your listening habits reveal a lot — the topics you seek out, the voices you trust, the
+            worlds you choose to tune into. We break down your subscriptions into categories and
+            patterns to paint a picture of your podcast personality.
+          </Text>
+          <Text c="gray.7">
+            Most podcast apps let you export an <Text component="span" fw={700}>OPML file</Text> — a
+            simple list of all the feeds you follow. Export it from your app, save it to your device,
+            then share it here to get your profile.
+          </Text>
+          <Text size="sm" c="gray.5" fs="italic">
+            No AI (yet) — just simple number crunching on your subscriptions.
+          </Text>
+          <Text c="gray.7">
+            Once you have your profile, share the link with friends and compare your podcast
+            personalities.
+          </Text>
+        </Stack>
+
+        <Divider />
+
+        <Title order={2} size="h4">Upload your OPML to get started</Title>
         <FileInput
           accept=".opml,.xml"
           placeholder="Choose OPML file"


### PR DESCRIPTION
Adds a hero intro section to the home page explaining what the app does —
podcast personality profiling via OPML upload, no AI, share with friends.
Renames the app from "Podcast Personality" to "Podnality" across title and
meta tags.

https://claude.ai/code/session_01ANDpMcHYzmQRdFqToENJWq