### PR TITLE
Add footer credits and meta tags

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -6,9 +6,16 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="What do your podcast subscriptions say about your personality? Upload your OPML and get an instant shareable profile — no AI, just number crunching." />
+    <meta name="author" content="Si Jobling" />
+    <meta name="keywords" content="podcasts, personality, OPML, podcast subscriptions, podcast profile" />
     <meta property="og:title" content="Podnality" />
     <meta property="og:description" content="What do your podcast subscriptions say about your personality? Find out with Podnality." />
     <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://github.com/si/podcasts-personality/" />
+    <meta name="twitter:card" content="summary" />
+    <meta name="twitter:title" content="Podnality" />
+    <meta name="twitter:description" content="What do your podcast subscriptions say about your personality? Find out with Podnality." />
+    <meta name="twitter:creator" content="@si" />
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>Podnality</title>

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -11,7 +11,7 @@
     <meta property="og:title" content="Podnality" />
     <meta property="og:description" content="What do your podcast subscriptions say about your personality? Find out with Podnality." />
     <meta property="og:type" content="website" />
-    <meta property="og:url" content="https://github.com/si/podcasts-personality/" />
+    <meta property="og:url" content="https://podnality.unstyled.com" />
     <meta name="twitter:card" content="summary" />
     <meta name="twitter:title" content="Podnality" />
     <meta name="twitter:description" content="What do your podcast subscriptions say about your personality? Find out with Podnality." />

--- a/client/src/Footer.tsx
+++ b/client/src/Footer.tsx
@@ -1,0 +1,49 @@
+import React from 'react';
+import { Box, Text, Anchor, Group } from '@mantine/core';
+
+function Footer() {
+  return (
+    <Box component="footer" py={24} ta="center">
+      <Group justify="center" gap="xs" wrap="wrap">
+        <Text size="sm" c="gray.5">
+          An{' '}
+          <Anchor
+            href="https://unstyled.club"
+            size="sm"
+            c="gray.5"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Unstyled
+          </Anchor>{' '}
+          product by{' '}
+          <Anchor
+            href="https://github.com/si"
+            size="sm"
+            c="gray.5"
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Si Jobling
+          </Anchor>
+        </Text>
+        <Text size="sm" c="gray.3">·</Text>
+        <Anchor
+          href="https://github.com/si/podcasts-personality/"
+          size="sm"
+          c="gray.5"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          GitHub
+        </Anchor>
+        <Text size="sm" c="gray.3">·</Text>
+        <Text size="sm" c="gray.5">Hosted on Railway</Text>
+        <Text size="sm" c="gray.3">·</Text>
+        <Text size="sm" c="gray.5">Built with Claude Code</Text>
+      </Group>
+    </Box>
+  );
+}
+
+export default Footer;

--- a/client/src/Footer.tsx
+++ b/client/src/Footer.tsx
@@ -8,7 +8,7 @@ function Footer() {
         <Text size="sm" c="gray.5">
           An{' '}
           <Anchor
-            href="https://unstyled.club"
+            href="https://unstyled.com"
             size="sm"
             c="gray.5"
             target="_blank"

--- a/client/src/ProfilePage.tsx
+++ b/client/src/ProfilePage.tsx
@@ -13,6 +13,7 @@ import {
 } from '@mantine/core';
 import axios from 'axios';
 import { toaster } from './toaster';
+import Footer from './Footer';
 
 interface Podcast {
   title: string;
@@ -747,6 +748,7 @@ function ProfilePage() {
           </>
         )}
       </Stack>
+      <Footer />
     </Box>
   );
 }

--- a/client/src/UploadPage.tsx
+++ b/client/src/UploadPage.tsx
@@ -12,6 +12,7 @@ import {
 import { useNavigate } from 'react-router-dom';
 import axios from 'axios';
 import { toaster } from './toaster';
+import Footer from './Footer';
 
 interface Podcast {
   title: string;
@@ -178,6 +179,7 @@ function UploadPage() {
           </Box>
         )}
       </Stack>
+      <Footer />
     </Box>
   );
 }


### PR DESCRIPTION
Adds a reusable Footer component crediting Si Jobling (Unstyled), linking to
the GitHub repo, Railway hosting, and Claude Code. Footer appears on both the
upload and profile pages. Also adds author, keywords, og:url, and Twitter Card
meta tags to index.html.

https://claude.ai/code/session_015az4KoFQR6pt83KCPYzbgZ