### PR TITLE
Add "Your Podcast Personality" title to all pages and SVG favicon

### DIFF
--- a/client/public/favicon.svg
+++ b/client/public/favicon.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <defs>
+    <linearGradient id="g" x1="0%" y1="0%" x2="100%" y2="100%">
+      <stop offset="0%" stop-color="#7c3aed"/>
+      <stop offset="100%" stop-color="#06b6d4"/>
+    </linearGradient>
+  </defs>
+  <rect width="32" height="32" rx="8" fill="url(#g)"/>
+  <text x="16" y="13" text-anchor="middle" fill="white" font-family="system-ui,sans-serif" font-weight="900" font-size="9">YOUR</text>
+  <text x="16" y="22" text-anchor="middle" fill="white" font-family="system-ui,sans-serif" font-weight="900" font-size="9">POD</text>
+  <text x="16" y="30" text-anchor="middle" fill="white" font-family="system-ui,sans-serif" font-weight="900" font-size="7.5">PERS.</text>
+</svg>

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -2,7 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="utf-8" />
-    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.svg" type="image/svg+xml" />
+    <link rel="icon" href="%PUBLIC_URL%/favicon.ico" sizes="any" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="theme-color" content="#000000" />
     <meta name="description" content="What do your podcast subscriptions say about your personality? Upload your OPML and get an instant shareable profile — no AI, just number crunching." />

--- a/client/src/ProfilePage.tsx
+++ b/client/src/ProfilePage.tsx
@@ -413,6 +413,16 @@ function ProfilePage() {
   return (
     <Box mih="100vh" bg="gray.0" py={40} px={16}>
       <Stack gap={24} maw={672} mx="auto" bg="white" p={32} style={{ borderRadius: 12, boxShadow: '0 1px 8px rgba(0,0,0,0.08)' }}>
+        <Text
+          variant="gradient"
+          gradient={{ from: 'violet', to: 'cyan' }}
+          fw={700}
+          style={{ fontSize: 20, cursor: 'pointer' }}
+          onClick={() => navigate('/')}
+        >
+          Your Podcast Personality
+        </Text>
+
         {loading && <Loader size="xl" mx="auto" />}
 
         {notFound && (

--- a/client/src/UploadPage.tsx
+++ b/client/src/UploadPage.tsx
@@ -99,6 +99,14 @@ function UploadPage() {
   return (
     <Box mih="100vh" bg="gray.0" py={40} px={16}>
       <Stack gap={24} maw={600} mx="auto" bg="white" p={32} style={{ borderRadius: 12, boxShadow: '0 1px 8px rgba(0,0,0,0.08)' }}>
+        <Text
+          variant="gradient"
+          gradient={{ from: 'violet', to: 'cyan' }}
+          fw={900}
+          style={{ fontSize: 42, lineHeight: 1.1 }}
+        >
+          Your Podcast Personality
+        </Text>
         <Stack gap={12}>
           <Title order={1} size="h2">What do your podcast subscriptions say about your personality?</Title>
           <Text c="gray.7">


### PR DESCRIPTION
- Homepage: large gradient title (42px) at top of card
- Profile page: smaller gradient title (20px) at top of card, clickable back to home
- New favicon.svg with violet-to-cyan gradient and abbreviated text mark
- index.html: prefer SVG favicon, keep .ico as fallback

https://claude.ai/code/session_01TALVKTK8nbnZmuGSa88Ypj