### PR TITLE
Add social identity verification for Bluesky, Mastodon, and custom domains

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,9 @@ RUN npm run build
 
 # Stage 2: Production server
 FROM node:18-alpine
-# Build tools required for native modules (better-sqlite3)
-RUN apk add --no-cache python3 make g++
 WORKDIR /app
 COPY package.json ./
-# Skip postinstall (frontend already built in stage 1), then rebuild native modules
-RUN npm install --omit=dev --ignore-scripts && npm rebuild better-sqlite3
+RUN npm install --omit=dev --ignore-scripts
 COPY server.js ./
 COPY --from=frontend-builder /app/client/build ./client/build
 ENV NODE_ENV=production

--- a/client/src/ProfilePage.tsx
+++ b/client/src/ProfilePage.tsx
@@ -20,11 +20,26 @@ interface Podcast {
   xmlurl: string;
 }
 
+interface SocialLink {
+  handle: string;
+  verified: boolean;
+}
+
+interface SocialDomain {
+  domain: string;
+  verified: boolean;
+}
+
 interface Profile {
   hash: string;
   name: string | null;
   podcasts: Podcast[];
   created_at: string;
+  social: {
+    bluesky: SocialLink | null;
+    mastodon: SocialLink | null;
+    domain: SocialDomain | null;
+  };
 }
 
 interface PodcastMetadata {
@@ -261,6 +276,9 @@ function ProfilePage() {
   const [nameInput, setNameInput] = useState('');
   const [savingName, setSavingName] = useState(false);
 
+  const [socialInput, setSocialInput] = useState({ bluesky: '', mastodon: '', domain: '' });
+  const [verifying, setVerifying] = useState<'bluesky' | 'mastodon' | 'domain' | null>(null);
+
   const [enriched, setEnriched] = useState<Record<string, PodcastMetadata | null>>({});
   const [enriching, setEnriching] = useState(false);
 
@@ -408,6 +426,32 @@ function ProfilePage() {
     }
   };
 
+  const handleVerify = async (platform: 'bluesky' | 'mastodon' | 'domain') => {
+    const handle = socialInput[platform].trim();
+    if (!handle) return;
+    setVerifying(platform);
+    try {
+      const res = await axios.post(`/api/profiles/${hash}/verify`, { platform, handle });
+      setProfile(prev => {
+        if (!prev) return prev;
+        const updated = { ...prev, social: { ...prev.social } };
+        if (platform === 'bluesky') updated.social.bluesky = { handle: res.data.handle, verified: res.data.verified };
+        if (platform === 'mastodon') updated.social.mastodon = { handle: res.data.handle, verified: res.data.verified };
+        if (platform === 'domain') updated.social.domain = { domain: res.data.domain, verified: res.data.verified };
+        return updated;
+      });
+      if (res.data.verified) {
+        toaster.create({ title: `${platform.charAt(0).toUpperCase() + platform.slice(1)} verified!`, type: 'success', duration: 2000 });
+      } else {
+        toaster.create({ title: res.data.message || 'Not verified yet', type: 'info', duration: 5000 });
+      }
+    } catch (err: any) {
+      toaster.create({ title: err.response?.data?.error || 'Verification failed', type: 'error', duration: 4000 });
+    } finally {
+      setVerifying(null);
+    }
+  };
+
   const showAnalysisPanel = !enriching && (categoryRatios.length > 0 || Object.keys(frequencyDistribution).length > 0);
 
   return (
@@ -435,15 +479,26 @@ function ProfilePage() {
 
         {profile && (
           <>
-            <Text
-              variant="gradient"
-              gradient={{ from: 'violet', to: 'cyan' }}
-              fw={900}
-              fz="xl"
-              style={{ fontSize: 26 }}
-            >
-              {profile.name ? `${profile.name}'s Profile` : 'Podcast Profile'}
-            </Text>
+            <Group gap={10} align="center" wrap="wrap">
+              <Text
+                variant="gradient"
+                gradient={{ from: 'violet', to: 'cyan' }}
+                fw={900}
+                fz="xl"
+                style={{ fontSize: 26 }}
+              >
+                {profile.name ? `${profile.name}'s Profile` : 'Podcast Profile'}
+              </Text>
+              {profile.social?.bluesky?.verified && (
+                <Badge size="sm" color="blue" variant="filled" title={`Verified Bluesky: @${profile.social.bluesky.handle}`}>🦋 Bluesky</Badge>
+              )}
+              {profile.social?.mastodon?.verified && (
+                <Badge size="sm" color="violet" variant="filled" title={`Verified Mastodon: @${profile.social.mastodon.handle}`}>🦣 Mastodon</Badge>
+              )}
+              {profile.social?.domain?.verified && (
+                <Badge size="sm" color="green" variant="filled" title={`Verified domain: ${profile.social.domain.domain}`}>🌐 {profile.social.domain.domain}</Badge>
+              )}
+            </Group>
 
             {/* Name form — only shown until a name has been saved */}
             {!profile.name && (
@@ -473,6 +528,107 @@ function ProfilePage() {
                 </Group>
               </Box>
             )}
+
+            {/* Social identity verification */}
+            <Box w="100%" p={16} style={{ borderRadius: 8, border: '1px solid var(--mantine-color-gray-2)' }}>
+              <Text size="sm" fw={600} mb={12} c="gray.7">
+                Verify your identity
+              </Text>
+              <Text size="xs" c="gray.5" mb={12}>
+                Link your podroll to your social profile so others can verify it's really you. Add your profile URL (<Text span size="xs" c="blue.5" ff="monospace">/p/{hash}</Text>) to your bio or DNS record first, then click Verify.
+              </Text>
+              <Stack gap={10}>
+                {/* Bluesky */}
+                <Group gap={8} align="flex-end">
+                  <Text size="lg" style={{ lineHeight: 1, paddingBottom: 6 }}>🦋</Text>
+                  <TextInput
+                    size="xs"
+                    placeholder="you.bsky.social"
+                    value={socialInput.bluesky || (profile.social?.bluesky?.handle ?? '')}
+                    onChange={e => setSocialInput(s => ({ ...s, bluesky: e.target.value }))}
+                    style={{ flex: 1 }}
+                    rightSection={profile.social?.bluesky?.verified ? <Text size="xs" c="teal">✓</Text> : null}
+                  />
+                  <Button
+                    size="xs"
+                    variant="light"
+                    color="blue"
+                    loading={verifying === 'bluesky'}
+                    disabled={!(socialInput.bluesky || profile.social?.bluesky?.handle)}
+                    onClick={() => handleVerify('bluesky')}
+                  >
+                    {profile.social?.bluesky?.verified ? 'Re-verify' : 'Verify'}
+                  </Button>
+                </Group>
+
+                {/* Mastodon */}
+                <Group gap={8} align="flex-end">
+                  <Text size="lg" style={{ lineHeight: 1, paddingBottom: 6 }}>🦣</Text>
+                  <TextInput
+                    size="xs"
+                    placeholder="you@mastodon.social"
+                    value={socialInput.mastodon || (profile.social?.mastodon?.handle ?? '')}
+                    onChange={e => setSocialInput(s => ({ ...s, mastodon: e.target.value }))}
+                    style={{ flex: 1 }}
+                    rightSection={profile.social?.mastodon?.verified ? <Text size="xs" c="teal">✓</Text> : null}
+                  />
+                  <Button
+                    size="xs"
+                    variant="light"
+                    color="violet"
+                    loading={verifying === 'mastodon'}
+                    disabled={!(socialInput.mastodon || profile.social?.mastodon?.handle)}
+                    onClick={() => handleVerify('mastodon')}
+                  >
+                    {profile.social?.mastodon?.verified ? 'Re-verify' : 'Verify'}
+                  </Button>
+                </Group>
+
+                {/* Domain */}
+                <Group gap={8} align="flex-end">
+                  <Text size="lg" style={{ lineHeight: 1, paddingBottom: 6 }}>🌐</Text>
+                  <TextInput
+                    size="xs"
+                    placeholder="yourdomain.com"
+                    value={socialInput.domain || (profile.social?.domain?.domain ?? '')}
+                    onChange={e => setSocialInput(s => ({ ...s, domain: e.target.value }))}
+                    style={{ flex: 1 }}
+                    rightSection={profile.social?.domain?.verified ? <Text size="xs" c="teal">✓</Text> : null}
+                  />
+                  <Button
+                    size="xs"
+                    variant="light"
+                    color="green"
+                    loading={verifying === 'domain'}
+                    disabled={!(socialInput.domain || profile.social?.domain?.domain)}
+                    onClick={() => handleVerify('domain')}
+                  >
+                    {profile.social?.domain?.verified ? 'Re-verify' : 'Verify'}
+                  </Button>
+                </Group>
+              </Stack>
+
+              {/* Verified badges summary */}
+              {(profile.social?.bluesky?.verified || profile.social?.mastodon?.verified || profile.social?.domain?.verified) && (
+                <Group gap={8} mt={12}>
+                  {profile.social?.bluesky?.verified && (
+                    <Badge size="sm" color="blue" variant="light" leftSection="🦋">
+                      @{profile.social.bluesky.handle}
+                    </Badge>
+                  )}
+                  {profile.social?.mastodon?.verified && (
+                    <Badge size="sm" color="violet" variant="light" leftSection="🦣">
+                      @{profile.social.mastodon.handle}
+                    </Badge>
+                  )}
+                  {profile.social?.domain?.verified && (
+                    <Badge size="sm" color="green" variant="light" leftSection="🌐">
+                      {profile.social.domain.domain}
+                    </Badge>
+                  )}
+                </Group>
+              )}
+            </Box>
 
             <Group w="100%" justify="space-between" align="center">
               <Text c="gray.5">{profile.podcasts.length} podcasts</Text>

--- a/server.js
+++ b/server.js
@@ -216,7 +216,6 @@ async function verifyDomain(hash, domain) {
     };
   }
 }
-}
 
 // ---- Podcast metadata cache ----
 

--- a/server.js
+++ b/server.js
@@ -4,6 +4,7 @@ const cors = require('cors');
 const path = require('path');
 const fs = require('fs');
 const crypto = require('crypto');
+const dns = require('dns').promises;
 const OPMLParser = require('opmlparser');
 const { Pool } = require('pg');
 const { XMLParser } = require('fast-xml-parser');
@@ -59,6 +60,13 @@ async function initDb() {
       website_url          TEXT
     )
   `);
+  // Social verification columns — safe to run against existing databases
+  await pool.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS bluesky_handle TEXT`);
+  await pool.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS mastodon_handle TEXT`);
+  await pool.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS verified_domain TEXT`);
+  await pool.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS bluesky_verified BOOLEAN DEFAULT FALSE`);
+  await pool.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS mastodon_verified BOOLEAN DEFAULT FALSE`);
+  await pool.query(`ALTER TABLE profiles ADD COLUMN IF NOT EXISTS domain_verified BOOLEAN DEFAULT FALSE`);
 }
 
 // Validate hash to prevent path traversal / SQL injection via param
@@ -92,6 +100,11 @@ async function loadProfile(hash) {
     name: row.name || null,
     podcasts: JSON.parse(row.podcasts),
     created_at: row.created_at,
+    social: {
+      bluesky: row.bluesky_handle ? { handle: row.bluesky_handle, verified: !!row.bluesky_verified } : null,
+      mastodon: row.mastodon_handle ? { handle: row.mastodon_handle, verified: !!row.mastodon_verified } : null,
+      domain: row.verified_domain ? { domain: row.verified_domain, verified: !!row.domain_verified } : null,
+    },
   };
 }
 
@@ -101,6 +114,108 @@ async function updateProfileName(hash, name) {
     [name, hash]
   );
   return rowCount > 0;
+}
+
+// ---- Social identity verification ----
+
+async function verifyBluesky(hash, handle) {
+  const normalized = handle.startsWith('@') ? handle.slice(1) : handle;
+  if (!normalized || normalized.length < 3) throw new Error('Invalid Bluesky handle');
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8000);
+  let profile;
+  try {
+    const resp = await fetch(
+      `https://public.api.bsky.app/xrpc/app.bsky.actor.getProfile?actor=${encodeURIComponent(normalized)}`,
+      { signal: controller.signal, headers: { 'User-Agent': 'Podnality/1.0' } }
+    );
+    if (!resp.ok) throw new Error(`Bluesky handle not found: @${normalized}`);
+    profile = await resp.json();
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const bio = profile.description || '';
+  if (!bio.includes(`/p/${hash}`)) {
+    return {
+      verified: false,
+      handle: normalized,
+      message: `Add your profile URL (/p/${hash}) to your Bluesky bio, then verify again.`,
+    };
+  }
+  return { verified: true, handle: normalized };
+}
+
+async function verifyMastodon(hash, handle) {
+  const stripped = handle.startsWith('@') ? handle.slice(1) : handle;
+  const parts = stripped.split('@');
+  if (parts.length !== 2 || !parts[0] || !parts[1]) {
+    throw new Error('Invalid Mastodon handle — use the format user@instance.social');
+  }
+  const [username, instance] = parts;
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8000);
+  let account;
+  try {
+    const resp = await fetch(
+      `https://${instance}/api/v1/accounts/lookup?acct=${encodeURIComponent(username)}`,
+      { signal: controller.signal, headers: { 'User-Agent': 'Podnality/1.0' } }
+    );
+    if (!resp.ok) throw new Error(`Mastodon account not found: ${stripped}`);
+    account = await resp.json();
+  } finally {
+    clearTimeout(timeout);
+  }
+
+  const needle = `/p/${hash}`;
+  const bio = account.note || '';
+  const fields = Array.isArray(account.fields) ? account.fields : [];
+  const hasLink =
+    bio.includes(needle) ||
+    fields.some(f => (f.value || '').includes(needle));
+
+  if (!hasLink) {
+    return {
+      verified: false,
+      handle: stripped,
+      message: `Add your profile URL (/p/${hash}) to your Mastodon bio or profile fields, then verify again.`,
+    };
+  }
+  return { verified: true, handle: stripped };
+}
+
+async function verifyDomain(hash, domain) {
+  const cleaned = domain
+    .replace(/^https?:\/\//, '')
+    .replace(/^www\./, '')
+    .split('/')[0]
+    .trim()
+    .toLowerCase();
+  if (!cleaned || !cleaned.includes('.')) throw new Error('Invalid domain name');
+
+  const txtHost = `_podnality.${cleaned}`;
+  const expected = `hash=${hash}`;
+  try {
+    const records = await dns.resolveTxt(txtHost);
+    const found = records.some(chunks => chunks.join('').includes(expected));
+    if (!found) {
+      return {
+        verified: false,
+        domain: cleaned,
+        message: `No matching TXT record found. Add a DNS TXT record for _podnality.${cleaned} with value: hash=${hash}`,
+      };
+    }
+    return { verified: true, domain: cleaned };
+  } catch {
+    return {
+      verified: false,
+      domain: cleaned,
+      message: `DNS lookup failed. Add a TXT record for _podnality.${cleaned} with value: hash=${hash}`,
+    };
+  }
+}
 }
 
 // ---- Podcast metadata cache ----
@@ -395,6 +510,49 @@ app.patch('/api/profiles/:hash', async (req, res) => {
   res.json({ name: trimmed });
 });
 
+// Verify social identity (Bluesky, Mastodon, or domain TXT record)
+app.post('/api/profiles/:hash/verify', async (req, res) => {
+  const { hash } = req.params;
+  if (!isValidHash(hash)) return res.status(400).json({ error: 'Invalid profile id' });
+
+  const profile = await loadProfile(hash);
+  if (!profile) return res.status(404).json({ error: 'Profile not found' });
+
+  const { platform, handle } = req.body;
+  if (!['bluesky', 'mastodon', 'domain'].includes(platform)) {
+    return res.status(400).json({ error: 'platform must be bluesky, mastodon, or domain' });
+  }
+  if (typeof handle !== 'string' || !handle.trim()) {
+    return res.status(400).json({ error: 'handle must be a non-empty string' });
+  }
+
+  try {
+    let result;
+    if (platform === 'bluesky') {
+      result = await verifyBluesky(hash, handle.trim());
+      await pool.query(
+        'UPDATE profiles SET bluesky_handle = $1, bluesky_verified = $2 WHERE hash = $3',
+        [result.handle, result.verified, hash]
+      );
+    } else if (platform === 'mastodon') {
+      result = await verifyMastodon(hash, handle.trim());
+      await pool.query(
+        'UPDATE profiles SET mastodon_handle = $1, mastodon_verified = $2 WHERE hash = $3',
+        [result.handle, result.verified, hash]
+      );
+    } else {
+      result = await verifyDomain(hash, handle.trim());
+      await pool.query(
+        'UPDATE profiles SET verified_domain = $1, domain_verified = $2 WHERE hash = $3',
+        [result.domain, result.verified, hash]
+      );
+    }
+    res.json(result);
+  } catch (err) {
+    res.status(400).json({ error: err.message });
+  }
+});
+
 // Enrich podcast metadata (with 24-hour cache per feed URL)
 app.post('/api/podcasts/enrich', async (req, res) => {
   const { xmlurls } = req.body;
@@ -579,9 +737,27 @@ if (process.env.NODE_ENV === 'production') {
     }
 
     const escape = s => s.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+
+    // Build rel="me" link tags for verified social identities
+    let relMeTags = '';
+    if (profile?.social) {
+      const { bluesky, mastodon, domain } = profile.social;
+      if (bluesky?.verified) {
+        relMeTags += `\n    <link rel="me" href="https://bsky.app/profile/${escape(bluesky.handle)}" />`;
+      }
+      if (mastodon?.verified) {
+        const [user, instance] = mastodon.handle.split('@');
+        relMeTags += `\n    <link rel="me" href="https://${escape(instance)}/@${escape(user)}" />`;
+        relMeTags += `\n    <meta name="fediverse:creator" content="@${escape(mastodon.handle)}" />`;
+      }
+      if (domain?.verified) {
+        relMeTags += `\n    <link rel="me" href="https://${escape(domain.domain)}" />`;
+      }
+    }
+
     const injected = html.replace(
       '<meta property="og:title" content="Podcast Personality" />',
-      `<meta property="og:title" content="${escape(title)}" />\n    <meta property="og:description" content="${escape(description)}" />`,
+      `<meta property="og:title" content="${escape(title)}" />\n    <meta property="og:description" content="${escape(description)}" />${relMeTags}`,
     ).replace(
       '<meta property="og:description" content="Discover what your podcast subscriptions say about your personality." />',
       '',


### PR DESCRIPTION
Users can now link their podroll profile to their Bluesky handle, Mastodon
account, or personal domain to prove ownership. Verification works by
checking that their social bio/fields or a DNS TXT record references their
profile URL — no OAuth required.

- DB: adds bluesky_handle, mastodon_handle, verified_domain + *_verified
  boolean columns via ALTER TABLE IF NOT EXISTS (safe for existing data)
- Backend: POST /api/profiles/:hash/verify — calls Bluesky public API,
  Mastodon instance lookup API, or dns.resolveTxt for _podnality.<domain>
- OpenGraph: verified profiles get <link rel="me"> and fediverse:creator
  meta tags injected into the profile HTML
- Frontend: new "Verify your identity" section with per-platform inputs
  and Verify buttons; verified badges shown inline with the profile name

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JzRemjrrPxa1o4C9y6moy5